### PR TITLE
Update Dockerfile and switch to Python 3.8

### DIFF
--- a/.github/workflows/test_runner.yaml
+++ b/.github/workflows/test_runner.yaml
@@ -14,7 +14,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v2
         with:
-          python-version: "3.7"
+          python-version: "3.8"
       - name: Install
         run: |
           set -xe
@@ -36,7 +36,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v2
         with:
-          python-version: "3.7"
+          python-version: "3.8"
       - uses: actions/cache@v2
         with:
           path: ${{ github.workspace }}/venv
@@ -55,7 +55,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v2
         with:
-          python-version: "3.7"
+          python-version: "3.8"
       - uses: actions/cache@v2
         with:
           path: ${{ github.workspace }}/venv
@@ -75,7 +75,7 @@ jobs:
     - uses: actions/checkout@v2
     - uses: actions/setup-python@v2
       with:
-        python-version: "3.7"
+        python-version: "3.8"
     - name: Install wheel package
       run: pip install wheel
     - name: Build package

--- a/requirements.in
+++ b/requirements.in
@@ -9,7 +9,7 @@
 # For more background on this see:
 # https://github.com/opensafely/cohort-extractor/pull/286
 #
-https://github.com/opensafely/ctds-binary/raw/b76175dd04baace2327518a78536d35bac6c7e2b/dist/ctds-1.12.0-cp37-cp37m-manylinux2014_x86_64.whl ; sys_platform == "linux"
+https://github.com/opensafely/ctds-binary/raw/9466f4bdb8eb70318256115c3bbb6b3ecc9351d0/dist/ctds-1.13.0-cp38-cp38-manylinux2014_x86_64.whl ; sys_platform == "linux"
 
 # We still use pyODBC in our tests because we use SQLAlchemy to set up our test
 # data and there's currently no SQLAlchemy adapter for cTDS. I managed to get

--- a/requirements.txt
+++ b/requirements.txt
@@ -34,7 +34,7 @@ click==7.1.2
     #   presto-python-client
 cryptography==3.3.1
     # via pyopenssl
-https://github.com/opensafely/ctds-binary/raw/b76175dd04baace2327518a78536d35bac6c7e2b/dist/ctds-1.12.0-cp37-cp37m-manylinux2014_x86_64.whl ; sys_platform == "linux"
+https://github.com/opensafely/ctds-binary/raw/9466f4bdb8eb70318256115c3bbb6b3ecc9351d0/dist/ctds-1.13.0-cp38-cp38-manylinux2014_x86_64.whl ; sys_platform == "linux"
     # via -r requirements.in
 cycler==0.10.0
     # via matplotlib
@@ -52,13 +52,6 @@ identify==1.5.11
     # via pre-commit
 idna==2.9
     # via requests
-importlib-metadata==3.3.0
-    # via
-    #   flake8
-    #   pluggy
-    #   pre-commit
-    #   pytest
-    #   virtualenv
 isort==5.7.0
     # via -r requirements.in
 kiwisolver==1.2.0
@@ -181,10 +174,7 @@ toml==0.10.2
 typed-ast==1.4.2
     # via black
 typing-extensions==3.7.4.3
-    # via
-    #   black
-    #   importlib-metadata
-    #   structlog
+    # via black
 urllib3==1.25.9
     # via requests
 virtualenv==20.2.2
@@ -193,8 +183,6 @@ wcwidth==0.1.9
     # via
     #   prettytable
     #   pytest
-zipp==3.4.0
-    # via importlib-metadata
 
 # The following packages are considered to be unsafe in a requirements file:
 # pip


### PR DESCRIPTION
This updates to Dockerfile to use the [base-docker][1] image, use pre-compiled Python binaries from apt rather than compiling using pyenv, and switches to Python 3.8.

Closes #419

[1]: https://github.com/opensafely-core/base-docker