### PR TITLE
fix: Remove push to old Docker registry

### DIFF
--- a/.github/workflows/build_and_publish.yaml
+++ b/.github/workflows/build_and_publish.yaml
@@ -73,6 +73,9 @@ jobs:
       run: |
         echo ${{ needs.tag-new-version.outputs.tag }} > cohortextractor/VERSION
     - name: Pull image
+      # Deliberately leaving the below as `opensafely` for now to avoid
+      # chicken-and-egg problem. Once we've published an image to
+      # `opensafely-core` we can update
       run: docker pull ghcr.io/opensafely/cohortextractor
     - name: Build image
       run: docker build . --file Dockerfile --tag $IMAGE_NAME
@@ -87,12 +90,3 @@ jobs:
         docker tag $IMAGE_NAME $IMAGE_ID:latest
         docker tag $IMAGE_NAME $IMAGE_ID:$VERSION
         docker push $IMAGE_ID:latest
-    # deprecated publish to our repo
-    - name: Build and publish to docker registry
-      uses: whoan/docker-build-with-cache-action@v5
-      with:
-        username: docker
-        password: "${{ secrets.OPENSAFELY_DOCKER_PASSWORD }}"
-        registry: docker.opensafely.org
-        image_name: cohortextractor
-        image_tag: latest,${{ needs.tag-new-version.outputs.tag }}


### PR DESCRIPTION
For now, we need to manually pull newly built images from `opensafely-core` and push them to `opensafely` so they can be used with the job-runner:
```
docker pull ghcr.io/opensafely-core/cohortextractor:latest
docker tag ghcr.io/opensafely-core/cohortextractor:latest ghcr.io/opensafely/cohortextractor:latest
docker push ghcr.io/opensafely/cohortextractor:latest
```