### PR TITLE
feat: Add numeric_value_in_range

### DIFF
--- a/cohortextractor/patients.py
+++ b/cohortextractor/patients.py
@@ -513,6 +513,7 @@ def with_these_clinical_events(
     returning="binary_flag",
     include_date_of_match=False,
     date_format=None,
+    numeric_value_in_range=(None, None),
     # Special (and probably temporary) arguments to support queries we need
     # to do right now. This API will need to be thought through properly at
     # some stage.
@@ -565,6 +566,9 @@ def with_these_clinical_events(
             ignored. if a events is found on this day, the date is not matched even it matches a
             code in the main `codelist`
         episode_defined_as: a string expression indicating how an episode should be defined
+        numeric_value_in_range: a pair of numbers `(lower, upper)`.  Only events whose
+            numeric value is between `lower` and `upper` are matched.  Either `lower` or
+            `upper` may be `None`.
         return_binary_flag: a boolean indicating if the number of matches in a period should be
             returned (deprecated: use `date_format` instead),
         return_number_of_matches_in_period: a boolean indicating if the number of matches in a period should be
@@ -693,8 +697,8 @@ def registered_practice_as_of(
 
     Args:
         date: date of interest as a string with the format `YYYY-MM-DD`. Filters results to the given date.
-        returning: a str defining the type of data to be returned. options include `msoa` (Middle Layer Super Output Area codes), 
-             `nuts1_region_name` (9 English regions), `stp_code` (Sustainability Transformation Partnerships codes) and `pseudo_id` 
+        returning: a str defining the type of data to be returned. options include `msoa` (Middle Layer Super Output Area codes),
+             `nuts1_region_name` (9 English regions), `stp_code` (Sustainability Transformation Partnerships codes) and `pseudo_id`
              (Pseudonymised GP practice identifier). The default value is `None`.
         return_expectations: a dict defining the `rate` and the `categories` returned with ratios
 

--- a/tests/test_emis_backend.py
+++ b/tests/test_emis_backend.py
@@ -375,6 +375,54 @@ def test_clinical_event_with_numeric_value():
     assert [x["asthma_value_date"] for x in results] == ["", "2002-01", ""]
 
 
+def test_clinical_event_with_numeric_value_filter():
+    condition_code = "195967001"
+    _make_clinical_events_selection(
+        condition_code,
+        patient_dates=[
+            [
+                ("2001-01-01", 1),
+                ("2001-01-02", 2),
+                ("2001-01-03", 3),
+                ("2001-01-04", 4),
+                ("2001-01-05", 5),
+            ],
+        ],
+    )
+    study = StudyDefinition(
+        population=patients.all(),
+        lower=patients.with_these_clinical_events(
+            codelist([condition_code], "snomedct"),
+            returning="numeric_value",
+            numeric_value_in_range=(3, None),
+            find_first_match_in_period=True,
+        ),
+        upper=patients.with_these_clinical_events(
+            codelist([condition_code], "snomedct"),
+            returning="numeric_value",
+            numeric_value_in_range=(None, 3),
+            find_first_match_in_period=True,
+        ),
+        both=patients.with_these_clinical_events(
+            codelist([condition_code], "snomedct"),
+            returning="numeric_value",
+            numeric_value_in_range=(2, 4),
+            find_first_match_in_period=True,
+        ),
+        neither=patients.with_these_clinical_events(
+            codelist([condition_code], "snomedct"),
+            returning="numeric_value",
+            numeric_value_in_range=(None, None),
+            find_first_match_in_period=True,
+        ),
+    )
+    results = study.to_dicts()
+    assert [x["lower"] for x in results] == ["3.0"]
+    assert [x["upper"] for x in results] == ["1.0"]
+    assert [x["both"] for x in results] == ["2.0"]
+    assert [x["neither"] for x in results] == ["1.0"]
+
+
 def test_clinical_event_with_category():
     session = make_session()
     session.add_all(


### PR DESCRIPTION
Fixes #458

I'm having second thoughts about whether this approach is better than adding `ignore_null_values`, with a note in the docs that NULLs are converted to zero in the TPP backend.  Thoughts?