### PR TITLE
fix: Restore column order for measures

### DIFF
--- a/cohortextractor/cohortextractor.py
+++ b/cohortextractor/cohortextractor.py
@@ -306,8 +306,10 @@ def _generate_measures(output_dir, study_name, suffix, skip_existing=False):
 
 def _calculate_measure_df(patient_df, measure):
     if measure.group_by:
-        columns = set([measure.numerator, measure.denominator, *measure.group_by])
-        measure_df = patient_df[list(columns)]
+        columns = [measure.numerator, measure.denominator, *measure.group_by]
+        # Remove duplicates but preserve order
+        columns = list(dict.fromkeys(columns).keys())
+        measure_df = patient_df[columns]
         measure_df = measure_df.groupby(measure.group_by).sum()
         measure_df = measure_df.reset_index()
     else:

--- a/tests/test_smoketest.py
+++ b/tests/test_smoketest.py
@@ -56,14 +56,12 @@ def test_smoketest(tmp_path):
     with open(tmp_path / "measure_liver_disease.csv") as f:
         contents = list(csv.reader(f))
 
-    assert set(contents[0]) == set(
-        [
-            "population",
-            "has_chronic_liver_disease",
-            "value",
-            "date",
-        ]
-    )
+    assert contents[0] == [
+        "has_chronic_liver_disease",
+        "population",
+        "value",
+        "date",
+    ]
 
 
 def _cohortextractor(*args):


### PR DESCRIPTION
PR #454 accidentally introduced indeterminacy to the column order for
measures output. #457 attempted to address this by using set comparison
for the headers in the test but this still left the row values in an
unexpected order leading to intermittent failures. This PR fixes the
root cause.