### PR TITLE
Support new SGSS tables and SGTF field

### DIFF
--- a/cohortextractor/process_covariate_definitions.py
+++ b/cohortextractor/process_covariate_definitions.py
@@ -348,6 +348,7 @@ class GetColumnType:
             "has_members_in_other_ehr_systems": "bool",
             "percentage_of_members_with_data_in_this_backend": "int",
             "msoa": "str",
+            "s_gene_target_failure": "str",
         }
         try:
             return mapping[returning]

--- a/cohortextractor/tpp_backend.py
+++ b/cohortextractor/tpp_backend.py
@@ -1638,35 +1638,22 @@ class TPPBackend:
             flag = 1 if test_result == "positive" else 0
             result_condition = f"test_result = {quote(flag)}"
 
-        # These are the values we're expecting in our SGSS tables. If we ever
-        # get anything other than these we should throw an error rather than
-        # blindly continuing.
-        positive_descr = "SARS-CoV-2 CORONAVIRUS (Covid-19)"
-        negative_descr = "NEGATIVE SARS-CoV-2 (COVID-19)"
-
         return f"""
         SELECT
           t.patient_id,
           1 AS binary_flag,
-          {date_aggregate}(t.date) AS date,
-          -- We have to calculate something over the error check field
-          -- otherwise it never gets computed
-          MAX(_e) AS _e
+          {date_aggregate}(t.date) AS date
         FROM (
           SELECT
             1 AS test_result,
             Patient_ID AS patient_id,
-            Earliest_Specimen_Date AS date,
-            -- Crude error check so we blow up in the case of unexpected data
-            1 / CASE WHEN Organism_Species_Name = '{positive_descr}' THEN 1 ELSE 0 END AS _e
+            Earliest_Specimen_Date AS date
           FROM SGSS_Positive
           UNION ALL
           SELECT
             0 AS test_result,
             Patient_ID AS patient_id,
-            Earliest_Specimen_Date AS date,
-            -- Crude error check so we blow up in the case of unexpected data
-            1 / CASE WHEN Organism_Species_Name = '{negative_descr}' THEN 1 ELSE 0 END AS _e
+            Earliest_Specimen_Date AS date
           FROM SGSS_Negative
         ) t
         {date_joins}

--- a/tests/test_tpp_backend.py
+++ b/tests/test_tpp_backend.py
@@ -2037,16 +2037,40 @@ def test_patients_with_test_result_in_sgss():
         [
             Patient(
                 SGSS_Positives=[
-                    SGSS_Positive(Earliest_Specimen_Date="2020-05-15"),
-                    SGSS_Positive(Earliest_Specimen_Date="2020-05-20"),
+                    SGSS_Positive(Earliest_Specimen_Date="2020-05-15", SGTF="9"),
+                    SGSS_Positive(Earliest_Specimen_Date="2020-05-20", SGTF="0"),
+                ],
+                SGSS_Negatives=[
+                    SGSS_Negative(Earliest_Specimen_Date="2020-05-02"),
+                    SGSS_Negative(Earliest_Specimen_Date="2020-07-10"),
+                ],
+                SGSS_AllTests_Positives=[
+                    SGSS_AllTests_Positive(Specimen_Date="2020-05-15"),
+                    SGSS_AllTests_Positive(Specimen_Date="2020-05-20"),
+                ],
+                SGSS_AllTests_Negatives=[
+                    SGSS_AllTests_Negative(Specimen_Date="2020-05-02"),
+                    SGSS_AllTests_Negative(Specimen_Date="2020-07-10"),
                 ],
             ),
             Patient(
                 SGSS_Negatives=[SGSS_Negative(Earliest_Specimen_Date="2020-04-01")],
-                SGSS_Positives=[SGSS_Positive(Earliest_Specimen_Date="2020-04-20")],
+                SGSS_Positives=[
+                    SGSS_Positive(Earliest_Specimen_Date="2020-04-20", SGTF="1")
+                ],
+                SGSS_AllTests_Negatives=[
+                    SGSS_AllTests_Negative(Specimen_Date="2020-04-01")
+                ],
+                SGSS_AllTests_Positives=[
+                    SGSS_AllTests_Positive(Specimen_Date="2020-04-20"),
+                    SGSS_AllTests_Positive(Specimen_Date="2020-05-02"),
+                ],
             ),
             Patient(
                 SGSS_Negatives=[SGSS_Negative(Earliest_Specimen_Date="2020-04-01")],
+                SGSS_AllTests_Negatives=[
+                    SGSS_AllTests_Negative(Specimen_Date="2020-04-01")
+                ],
             ),
             Patient(),
         ]
@@ -2072,17 +2096,45 @@ def test_patients_with_test_result_in_sgss():
             returning="date",
             date_format="YYYY-MM-DD",
         ),
+        first_negative_after_a_positive=patients.with_test_result_in_sgss(
+            pathogen="SARS-CoV-2",
+            test_result="negative",
+            on_or_after="first_positive_test_date",
+            find_first_match_in_period=True,
+            returning="date",
+            date_format="YYYY-MM-DD",
+            restrict_to_earliest_specimen_date=False,
+        ),
+        last_positive_test_date=patients.with_test_result_in_sgss(
+            pathogen="SARS-CoV-2",
+            test_result="positive",
+            find_last_match_in_period=True,
+            restrict_to_earliest_specimen_date=False,
+            returning="date",
+            date_format="YYYY-MM-DD",
+        ),
+        sgtf_result=patients.with_test_result_in_sgss(
+            pathogen="SARS-CoV-2",
+            test_result="positive",
+            find_first_match_in_period=True,
+            returning="s_gene_target_failure",
+        ),
     )
-    results = study.to_dicts()
-    assert [x["positive_covid_test_ever"] for x in results] == ["1", "1", "0", "0"]
-    assert [x["negative_covid_test_ever"] for x in results] == ["0", "1", "1", "0"]
-    assert [x["tested_before_may"] for x in results] == ["0", "1", "1", "0"]
-    assert [x["first_positive_test_date"] for x in results] == [
-        "2020-05-15",
-        "2020-04-20",
-        "",
-        "",
-    ]
+    assert_results(
+        study.to_dicts(),
+        positive_covid_test_ever=["1", "1", "0", "0"],
+        negative_covid_test_ever=["1", "1", "1", "0"],
+        tested_before_may=["0", "1", "1", "0"],
+        first_positive_test_date=[
+            "2020-05-15",
+            "2020-04-20",
+            "",
+            "",
+        ],
+        first_negative_after_a_positive=["2020-07-10", "", "", ""],
+        last_positive_test_date=["2020-05-20", "2020-05-02", "", ""],
+        sgtf_result=["9", "1", "", ""],
+    )
 
 
 def test_patients_date_of_birth():

--- a/tests/test_tpp_backend.py
+++ b/tests/test_tpp_backend.py
@@ -37,6 +37,8 @@ from tests.tpp_backend_setup import (
     PatientAddress,
     PotentialCareHomeAddress,
     RegistrationHistory,
+    SGSS_AllTests_Negative,
+    SGSS_AllTests_Positive,
     SGSS_Negative,
     SGSS_Positive,
     Vaccination,
@@ -70,8 +72,10 @@ def setup_function(function):
     session.query(Vaccination).delete()
     session.query(VaccinationReference).delete()
     session.query(Appointment).delete()
-    session.query(SGSS_Positive).delete()
+    session.query(SGSS_AllTests_Negative).delete()
+    session.query(SGSS_AllTests_Positive).delete()
     session.query(SGSS_Negative).delete()
+    session.query(SGSS_Positive).delete()
     session.query(MedicationIssue).delete()
     session.query(MedicationDictionary).delete()
     session.query(RegistrationHistory).delete()

--- a/tests/test_tpp_backend.py
+++ b/tests/test_tpp_backend.py
@@ -2081,28 +2081,6 @@ def test_patients_with_test_result_in_sgss():
     ]
 
 
-@pytest.mark.parametrize("positive", [True, False])
-def test_patients_with_test_result_in_sgss_raises_error_on_bad_data(positive):
-    kwargs = dict(
-        Earliest_Specimen_Date="2020-05-15", Organism_Species_Name="unexpected"
-    )
-    if positive:
-        patient = Patient(SGSS_Positives=[SGSS_Positive(**kwargs)])
-    else:
-        patient = Patient(SGSS_Negatives=[SGSS_Negative(**kwargs)])
-    session = make_session()
-    session.add(patient)
-    session.commit()
-    study = StudyDefinition(
-        population=patients.all(),
-        covid_test=patients.with_test_result_in_sgss(
-            pathogen="SARS-CoV-2",
-        ),
-    )
-    with pytest.raises(Exception):
-        study.to_dicts()
-
-
 def test_patients_date_of_birth():
     session = make_session()
     session.add_all(


### PR DESCRIPTION
The updated docstring in `patients.py` contains most of the detail here.

It's now possible to access the "AllTests" data (as opposed to the "Earliest Specimen Date" data) by passing the flag:
`restrict_to_earliest_specimen_date = False` e.g

```py
last_positive_test_date=patients.with_test_result_in_sgss(
    pathogen="SARS-CoV-2",
    test_result="positive",
    find_last_match_in_period=True,
    restrict_to_earliest_specimen_date=False,
    returning="date",
    date_format="YYYY-MM-DD",
    return_expectations={
        "date": {"earliest" : "2020-02-01"},
        "rate" : "exponential_increase"
    },
)
```


S-gene target failure results can be obtained using `returning = "s_gene_target_failure"` e.g.
```py
sgtf_result=patients.with_test_result_in_sgss(
    pathogen="SARS-CoV-2",
    test_result="positive",
    find_last_match_in_period=True,
    restrict_to_earliest_specimen_date=True,
    returning="s_gene_target_failure",
    return_expectations={
        "rate": "universal",
        "category": {
            "ratios": {
                "": 0.7,
                "0": 0.1,
                "1": 0.1,
                "9": 0.1,
            },
        },
    },

)
```

Note it's **not** possible to combine both the "AllTests" and "SGTF" options because the underlying data doesn't provide this. The cohortextractor will shout loudly at you if you try.

Closes #437 and #436