### PR TITLE
chore: ignore more directories from the dev tooling

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,5 +1,5 @@
 [flake8]
-exclude = .direnv,.venv,venv
+exclude = *.egg-info,.direnv,.venv,certs,mssql,presto,venv
 ignore = \
     E203 \ # whitespace before ':' (black disagrees)
     E501 \ # line too long (black fixes long lines, except for long strings which may benefit from being long (eg URLs))

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,18 @@
+[tool.black]
+exclude = '''
+(
+  /(
+      \.git         # exclude a few common directories in the
+    | \.direnv      # root of the project
+    | \.venv
+    | certs
+    | mssql
+    | presto
+    | venv
+  )/
+)
+'''
+
 [tool.isort]
 multi_line_output = 3
 include_trailing_comma = true
@@ -5,3 +20,4 @@ force_grid_wrap = 0
 use_parentheses = true
 ensure_newline_before_comments = true
 line_length = 88
+skip_glob = ["*.egg-info", ".direnv", ".venv", "certs", "mssql", "presto", "venv"]


### PR DESCRIPTION
This ignores some more directories from our dev tooling in an attempt to speed up those tools.  While it's good to only run them on the directories we care about, I did not fix my speed issue (3k lines in one test module coupled with running all the tools on leaving insert mode makes for an unhappy time), however I think these bits of config are generally good to have?