### PR TITLE
Fix with_ethnicity_from_sus Docstring

### DIFF
--- a/cohortextractor/patients.py
+++ b/cohortextractor/patients.py
@@ -1932,15 +1932,14 @@ def with_ethnicity_from_sus(
     Returns ethnicity data from the SUS Datasets
 
     Args:
-        returning: a string indicating what type of value whould be returned.
-        Options are:
+        returning: a string indicating what type of value whould be returned. Options are:
             code: don't group ethnicities at all, return the recorded code
             group_6: group ethnicities into 6 groups
             group_16: group ethnicities into 16 groups
         use_most_frequent_code: when multiple codes are present, pick the most
-        frequent one
+            frequent one
         return_expectations: a dictionary describing what dummy data should
-        look like
+            look like
 
     Example:
         ethnicity_by_16_grouping=patients.with_ethnicity_from_sus(

--- a/cohortextractor/patients.py
+++ b/cohortextractor/patients.py
@@ -1942,8 +1942,11 @@ def with_ethnicity_from_sus(
             look like
 
     Example:
-        ethnicity_by_16_grouping=patients.with_ethnicity_from_sus(
-            returning="group_16"
-        )
+        Patients with ethnicity, grouped to our 16 categories:
+
+            ethnicity_by_16_grouping=patients.with_ethnicity_from_sus(
+                returning="group_16",
+                use_most_frequent_code=True,
+            )
     """
     return "with_ethnicity_from_sus", locals()


### PR DESCRIPTION
This fixes the `with_ethnicity_from_sus` docstring so it's correctly formatted by our docs.  I've tested these changes in the docs repo to confirm the formatting is correct:

![](https://p198.p4.n0.cdn.getcloudapp.com/items/nOulyzvP/8db9bba1-eaec-4f54-bda9-239092512a3b.jpg?v=d9c038914fc5877dc32bf3241a26211e)