### PR TITLE
feat: Support additional APCS/SUS fields

### DIFF
--- a/cohortextractor/patients.py
+++ b/cohortextractor/patients.py
@@ -1812,6 +1812,12 @@ def admitted_to_hospital(
     with_these_diagnoses=None,
     with_these_primary_diagnoses=None,
     with_these_procedures=None,
+    with_admission_method=None,
+    with_source_of_admission=None,
+    with_discharge_destination=None,
+    with_patient_classification=None,
+    with_admission_treatment_function_code=None,
+    with_administrative_category=None,
     return_expectations=None,
 ):
     """
@@ -1832,6 +1838,14 @@ def admitted_to_hospital(
             date_discharged: date patient discharged from hospital
             number_of_matches_in_period: number of times patient was admitted in time period specified
             primary_diagnosis: primary diagnosis code for admission
+            admission_method:
+            source_of_admission:
+            discharge_destination:
+            patient_classification:
+            admission_treatment_function_code:
+            days_in_critical_care:
+            administrative_category:
+            duration_of_elective_wait:
         find_first_match_in_period: a boolean that indicates if the data returned is first event
             if there are multiple matches within the time period
         find_last_match_in_period: a boolean that indicates if the data returned is last event
@@ -1842,6 +1856,12 @@ def admitted_to_hospital(
         with_these_diagnoses: icd10 codes to match against any diagnosis
         with_these_primary_diagnoses: icd10 codes to match against the primary diagnosis
         with_these_procedures: opcs4 codes to match against the procedure
+        with_admission_method: string or list of strings to match against
+        with_source_of_admission: string or list of strings to match against
+        with_discharge_destination: string or list of strings to match against
+        with_patient_classification: string or list of strings to match against
+        with_admission_treatment_function_code: string or list of strings to match against
+        with_administrative_category: string or list of strings to match against
         return_expectations: a dictionary defining the incidence and distribution of expected value
             within the population in question.
 

--- a/cohortextractor/process_covariate_definitions.py
+++ b/cohortextractor/process_covariate_definitions.py
@@ -358,6 +358,14 @@ class GetColumnType:
             "case_category": "str",
             "group_6": "str",
             "group_16": "str",
+            "admission_method": "str",
+            "source_of_admission": "str",
+            "dischage_destination": "str",
+            "patient_classification": "str",
+            "admission_treatment_function_code": "str",
+            "days_in_critical_care": "str",
+            "administrative_category": "str",
+            "duration_of_elective_wait": "str",
         }
         try:
             return mapping[returning]

--- a/tests/test_tpp_backend.py
+++ b/tests/test_tpp_backend.py
@@ -2698,7 +2698,14 @@ def test_patients_admitted_to_hospital():
                         Discharge_Date="2020-03-01",
                         Der_Diagnosis_All="||AAAA ,XXXA, XXXB",
                         Der_Procedure_All="||AAAA ,YYYA, YYYB",
-                        APCS_Der=APCS_Der(Patient_ID=2, Spell_Primary_Diagnosis="AAAA"),
+                        Discharge_Destination="11",
+                        Source_of_Admission="2A",
+                        Admission_Method="11",
+                        APCS_Der=APCS_Der(
+                            Patient_ID=2,
+                            Spell_Primary_Diagnosis="AAAA",
+                            Spell_PbR_CC_Day="3",
+                        ),
                     )
                 ],
             ),
@@ -2712,7 +2719,14 @@ def test_patients_admitted_to_hospital():
                         Discharge_Date="2020-02-01",
                         Der_Diagnosis_All="||BBBB ,XXXB, XXXC",
                         Der_Procedure_All="||BBBB ,YYYB, YYYC",
-                        APCS_Der=APCS_Der(Patient_ID=3, Spell_Primary_Diagnosis="BBBB"),
+                        Discharge_Destination="99",
+                        Source_of_Admission="2A",
+                        Admission_Method="50",
+                        APCS_Der=APCS_Der(
+                            Patient_ID=3,
+                            Spell_Primary_Diagnosis="BBBB",
+                            Spell_PbR_CC_Day="4",
+                        ),
                     ),
                     APCS(
                         APCS_Ident=3,
@@ -2734,7 +2748,14 @@ def test_patients_admitted_to_hospital():
                         Discharge_Date="2020-04-01",
                         Der_Diagnosis_All="||DDDD ,XXXD, XXXE",
                         Der_Procedure_All="||DDDD ,YYYD, YYYE",
-                        APCS_Der=APCS_Der(Patient_ID=4, Spell_Primary_Diagnosis="DDDD"),
+                        Discharge_Destination="11",
+                        Source_of_Admission="3B",
+                        Admission_Method="99",
+                        APCS_Der=APCS_Der(
+                            Patient_ID=4,
+                            Spell_Primary_Diagnosis="DDDD",
+                            Spell_PbR_CC_Day="5",
+                        ),
                     ),
                     APCS(
                         APCS_Ident=5,
@@ -2831,6 +2852,14 @@ def test_patients_admitted_to_hospital():
             returning="primary_diagnosis",
             find_last_match_in_period=True,
         ),
+        discharge_dest=patients.admitted_to_hospital(
+            with_source_of_admission="2A",
+            returning="discharge_destination",
+        ),
+        critical_care_days=patients.admitted_to_hospital(
+            with_admission_method=["11", "99"],
+            returning="days_in_critical_care",
+        ),
     )
 
     assert_results(
@@ -2849,6 +2878,8 @@ def test_patients_admitted_to_hospital():
         with_particular_procedures=["0", "0", "1", "2"],
         first_primary_diagnosis=["", "", "CCCC", "DDDD"],
         last_primary_diagnosis=["", "", "CCCC", "FFFF"],
+        discharge_dest=["", "11", "99", ""],
+        critical_care_days=["", "3", "", "5"],
     )
 
 

--- a/tests/tpp_backend_setup.py
+++ b/tests/tpp_backend_setup.py
@@ -655,6 +655,13 @@ class APCS(Base):
     Der_Diagnosis_All = Column(String)
     Der_Procedure_All = Column(String)
     Ethnic_Group = Column(String)
+    Admission_Method = Column(String)
+    Source_of_Admission = Column(String)
+    Discharge_Destination = Column(String)
+    Patient_Classification = Column(String)
+    Der_Admit_Treatment_Function_Code = Column(String)
+    Administrative_Category = Column(String)
+    Duration_of_Elective_Wait = Column(String)
 
 
 class APCS_Der(Base):
@@ -667,6 +674,7 @@ class APCS_Der(Base):
     APCS = relationship("APCS", back_populates="APCS_Der")
     Spell_Primary_Diagnosis = Column(String)
     Spell_Secondary_Diagnosis = Column(String)
+    Spell_PbR_CC_Day = Column(String)
 
 
 class HighCostDrugs(Base):


### PR DESCRIPTION
This adds support for the following fields:

    admission_method
    source_of_admission
    discharge_destination
    patient_classification
    admission_treatment_function_code
    days_in_critical_care
    administrative_category
    duration_of_elective_wait

Each of these can be used as a `returning` option in
`patients.admitted_to_hospital()`.

Additionally, each of these can be used as filtering option by
prepending `with_` to the column name e.g.

```py
discharge_destination=patients.admitted_to_hospital(
    with_source_of_admission="2A",
    returning="discharge_destination",
)
```

As well as a single string you can match against a list of strings:
```py
discharge_destination=patients.admitted_to_hospital(
    with_source_of_admission=["11", "99", "2A"],
    returning="discharge_destination",
)
```

Closes #414