### PR TITLE
fix: Log number of results downloaded in EMIS backend

### DIFF
--- a/cohortextractor/emis_backend.py
+++ b/cohortextractor/emis_backend.py
@@ -84,8 +84,11 @@ class EMISBackend:
             writer.writerow([x[0] for x in result.description])
             for ix, row in enumerate(result):
                 unique_check.add(row[0])
+                if unique_check.count % 1000000 == 0:
+                    logger.info(f"Downloaded {unique_check.count} results")
                 row[0] = ix
                 writer.writerow(row)
+        logger.info(f"Downloaded {unique_check.count} results")
         unique_check.assert_unique_ids()
 
     def to_dicts(self):


### PR DESCRIPTION
This just duplicates behaviour already present in the TPP backend.

Closes #490