### PR TITLE
Support binary output formats

### DIFF
--- a/cohortextractor/README.md
+++ b/cohortextractor/README.md
@@ -33,7 +33,7 @@ is developing. The `Codelist` object it returns is just a list of codes
 with an additional `system` attribute.
 
 The [generate_cohort.py](../generate_cohort.py) file just imports the
-study definition object and calls `to_csv` on it.
+study definition object and calls `to_file` on it.
 
 Each keyword argument to `StudyDefinition` generates a column in the
 resulting CSV. The exception is `population` which defines the list of

--- a/cohortextractor/cohortextractor.py
+++ b/cohortextractor/cohortextractor.py
@@ -41,6 +41,9 @@ notebook_tag = "opencorona-research"
 target_dir = "/home/app/notebook"
 
 
+SUPPORTED_FILE_FORMATS = ["csv"]
+
+
 def show_exception_timestamp(*args):
     """
     Output a timestamp before any exception traceback which can be useful when
@@ -133,6 +136,7 @@ def generate_cohort(
     selected_study_name=None,
     index_date_range=None,
     skip_existing=False,
+    output_format=SUPPORTED_FILE_FORMATS[0],
 ):
     preflight_generation_check()
     study_definitions = list_study_definitions()
@@ -149,6 +153,7 @@ def generate_cohort(
             expectations_population,
             index_date_range=index_date_range,
             skip_existing=skip_existing,
+            output_format=output_format,
         )
 
 
@@ -159,6 +164,7 @@ def _generate_cohort(
     expectations_population,
     index_date_range=None,
     skip_existing=False,
+    output_format=SUPPORTED_FILE_FORMATS[0],
 ):
     logger.info(
         f"Generating cohort for {study_name} in {output_dir}",
@@ -169,6 +175,7 @@ def _generate_cohort(
         expectations_population=expectations_population,
         index_date_range=index_date_range,
         skip_existing=skip_existing,
+        output_format=output_format,
     )
 
     study = load_study_definition(study_name)
@@ -183,7 +190,7 @@ def _generate_cohort(
             date_suffix = ""
         # If this is changed then the glob pattern in `_generate_measures()`
         # must be updated
-        output_file = f"{output_dir}/input{suffix}{date_suffix}.csv"
+        output_file = f"{output_dir}/input{suffix}{date_suffix}.{output_format}"
         if skip_existing and os.path.exists(output_file):
             logger.info(f"Not regenerating pre-existing file at {output_file}")
         else:
@@ -255,7 +262,12 @@ def _increment_date(date, period):
         raise ValueError(f"Unknown time period '{period}'")
 
 
-def generate_measures(output_dir, selected_study_name=None, skip_existing=False):
+def generate_measures(
+    output_dir,
+    selected_study_name=None,
+    skip_existing=False,
+    output_format=SUPPORTED_FILE_FORMATS[0],
+):
     preflight_generation_check()
     study_definitions = list_study_definitions()
     if selected_study_name and selected_study_name != "all":
@@ -264,18 +276,32 @@ def generate_measures(output_dir, selected_study_name=None, skip_existing=False)
                 study_definitions = [(study_name, suffix)]
                 break
     for study_name, suffix in study_definitions:
-        _generate_measures(output_dir, study_name, suffix, skip_existing=skip_existing)
+        _generate_measures(
+            output_dir,
+            study_name,
+            suffix,
+            skip_existing=skip_existing,
+            output_format=output_format,
+        )
 
 
-def _generate_measures(output_dir, study_name, suffix, skip_existing=False):
+def _generate_measures(
+    output_dir,
+    study_name,
+    suffix,
+    skip_existing=False,
+    output_format=SUPPORTED_FILE_FORMATS[0],
+):
     logger.info(
         "Generating measure for {study_name} in {output_dir}",
     )
-    logger.debug("args", suffix=suffix, skip_existing=skip_existing)
+    logger.debug(
+        "args", suffix=suffix, skip_existing=skip_existing, output_format=output_format
+    )
     measures = load_study_definition(study_name, value="measures")
     measure_outputs = defaultdict(list)
-    for file in glob.glob(f"{output_dir}/input{suffix}*.csv"):
-        date = _get_date_from_filename(file)
+    for file in glob.glob(f"{output_dir}/input{suffix}*.{output_format}"):
+        date = _get_date_from_filename(file, output_format)
         if date is None:
             continue
         patient_df = None
@@ -288,7 +314,7 @@ def _generate_measures(output_dir, study_name, suffix, skip_existing=False):
             # We do this lazily so that if all corresponding output files
             # already exist we can avoid loading the patient data entirely
             if patient_df is None:
-                patient_df = _load_csv_for_measures(file, measures)
+                patient_df = _load_dataframe_for_measures(file, measures)
             measure_df = _calculate_measure_df(patient_df, measure)
             measure_df.to_csv(output_file, index=False)
             logger.info(f"Created measure output at {output_file}")
@@ -320,16 +346,18 @@ def _calculate_measure_df(patient_df, measure):
     return measure_df
 
 
-def _get_date_from_filename(filename):
-    match = re.search(r"_(\d\d\d\d\-\d\d\-\d\d)\.csv$", filename)
+def _get_date_from_filename(filename, output_format):
+    extension = re.escape(output_format)
+    match = re.search(fr"_(\d\d\d\d\-\d\d\-\d\d)\.{extension}$", filename)
     return datetime.date.fromisoformat(match.group(1)) if match else None
 
 
-def _load_csv_for_measures(file, measures):
+def _load_dataframe_for_measures(file, measures):
     """
-    Given a CSV file name and a list of measures, load the file into a Pandas
+    Given a file name and a list of measures, load the file into a Pandas
     dataframe with types as appropriate for the supplied measures
     """
+    extension = os.path.splitext(file)[1].lstrip(".")
     numeric_columns = set()
     group_by_columns = set()
     for measure in measures:
@@ -342,9 +370,12 @@ def _load_csv_for_measures(file, measures):
     dtype = {col: "category" for col in group_by_columns}
     for col in numeric_columns:
         dtype[col] = "float64"
-    df = pandas.read_csv(
-        file, dtype=dtype, usecols=list(dtype.keys()), keep_default_na=False
-    )
+    if extension == "csv":
+        df = pandas.read_csv(
+            file, dtype=dtype, usecols=list(dtype.keys()), keep_default_na=False
+        )
+    else:
+        raise RuntimeError(f"Unsupported extension: {extension}")
     df["population"] = 1
     return df
 
@@ -363,7 +394,7 @@ def _combine_csv_files_with_dates(filename, input_files):
         writer = csv.writer(csvfile)
         writer.writerow(headers + ["date"])
         for file in input_files:
-            date = _get_date_from_filename(file)
+            date = _get_date_from_filename(file, "csv")
             with open(file) as input_csvfile:
                 reader = csv.reader(input_csvfile)
                 if next(reader) != headers:
@@ -612,9 +643,19 @@ def main():
     # Cohort parser options
     generate_cohort_parser.add_argument(
         "--output-dir",
-        help="Location to store output CSVs",
+        help="Location to store output files",
         type=str,
         default="output",
+    )
+    generate_cohort_parser.add_argument(
+        "--output-format",
+        help=(
+            f"Output file format: {SUPPORTED_FILE_FORMATS[0]} (default),"
+            f" {', '.join(SUPPORTED_FILE_FORMATS[1:])}"
+        ),
+        type=str,
+        choices=SUPPORTED_FILE_FORMATS,
+        default=SUPPORTED_FILE_FORMATS[0],
     )
     generate_cohort_parser.add_argument(
         "--study-definition",
@@ -656,9 +697,20 @@ def main():
     # Measure generator parser options
     generate_measures_parser.add_argument(
         "--output-dir",
-        help="Location to store output CSVs",
+        help="Location to store output files",
         type=str,
         default="output",
+    )
+    generate_measures_parser.add_argument(
+        "--output-format",
+        help=(
+            f"File format for extracted cohorts (note measures files themselves will"
+            f" always be CSV): {SUPPORTED_FILE_FORMATS[0]} (default),"
+            f" {', '.join(SUPPORTED_FILE_FORMATS[1:])}"
+        ),
+        type=str,
+        choices=SUPPORTED_FILE_FORMATS,
+        default=SUPPORTED_FILE_FORMATS[0],
     )
     generate_measures_parser.add_argument(
         "--study-definition",
@@ -698,12 +750,14 @@ def main():
             selected_study_name=options.study_definition,
             index_date_range=options.index_date_range,
             skip_existing=options.skip_existing,
+            output_format=options.output_format,
         )
     elif options.which == "generate_measures":
         generate_measures(
             options.output_dir,
             selected_study_name=options.study_definition,
             skip_existing=options.skip_existing,
+            output_format=options.output_format,
         )
     elif options.which == "run":
         log_level = options.verbose and logging.DEBUG or logging.ERROR

--- a/cohortextractor/cohortextractor.py
+++ b/cohortextractor/cohortextractor.py
@@ -41,7 +41,7 @@ notebook_tag = "opencorona-research"
 target_dir = "/home/app/notebook"
 
 
-SUPPORTED_FILE_FORMATS = ["csv", "feather", "dta"]
+SUPPORTED_FILE_FORMATS = ["csv", "csv.gz", "feather", "dta", "dta.gz"]
 EXTENSION_REGEX = "|".join(map(re.escape, SUPPORTED_FILE_FORMATS))
 
 
@@ -369,13 +369,13 @@ def _load_dataframe_for_measures(filename, measures):
     dtype = {col: "category" for col in group_by_columns}
     for col in numeric_columns:
         dtype[col] = "float64"
-    if filename.endswith(".csv"):
+    if filename.endswith(".csv") or filename.endswith(".csv.gz"):
         df = pandas.read_csv(
             filename, dtype=dtype, usecols=list(dtype.keys()), keep_default_na=False
         )
     elif filename.endswith(".feather"):
         df = pandas.read_feather(filename, columns=list(dtype.keys()))
-    elif filename.endswith(".dta"):
+    elif filename.endswith(".dta") or filename.endswith(".dta.gz"):
         df = pandas.read_stata(filename, columns=list(dtype.keys()))
     else:
         raise RuntimeError(f"Unsupported file format: {filename}")

--- a/cohortextractor/cohortextractor.py
+++ b/cohortextractor/cohortextractor.py
@@ -41,7 +41,7 @@ notebook_tag = "opencorona-research"
 target_dir = "/home/app/notebook"
 
 
-SUPPORTED_FILE_FORMATS = ["csv"]
+SUPPORTED_FILE_FORMATS = ["csv", "feather", "dta"]
 
 
 def show_exception_timestamp(*args):
@@ -374,6 +374,10 @@ def _load_dataframe_for_measures(file, measures):
         df = pandas.read_csv(
             file, dtype=dtype, usecols=list(dtype.keys()), keep_default_na=False
         )
+    elif extension == "feather":
+        df = pandas.read_feather(file, columns=list(dtype.keys()))
+    elif extension == "dta":
+        df = pandas.read_stata(file, columns=list(dtype.keys()))
     else:
         raise RuntimeError(f"Unsupported extension: {extension}")
     df["population"] = 1

--- a/cohortextractor/cohortextractor.py
+++ b/cohortextractor/cohortextractor.py
@@ -187,7 +187,7 @@ def _generate_cohort(
         if skip_existing and os.path.exists(output_file):
             logger.info(f"Not regenerating pre-existing file at {output_file}")
         else:
-            study.to_csv(
+            study.to_file(
                 output_file,
                 expectations_population=expectations_population,
             )

--- a/cohortextractor/dashboards/vaccinations.py
+++ b/cohortextractor/dashboards/vaccinations.py
@@ -101,7 +101,8 @@ class VaccinationsStudyDefinition:
         )
         self.database_url = os.environ.get("DATABASE_URL")
 
-    def to_csv(self, filename, expectations_population=False):
+    def to_file(self, filename, expectations_population=False):
+        assert str(filename).endswith(".csv")
         if expectations_population:
             self.write_dummy_data(filename, expectations_population)
         else:

--- a/cohortextractor/emis_backend.py
+++ b/cohortextractor/emis_backend.py
@@ -1,5 +1,6 @@
 import csv
 import datetime
+import gzip
 import os
 import re
 import uuid
@@ -85,6 +86,13 @@ class EMISBackend:
         if str(filename).endswith(".csv"):
             with open(filename, "w", newline="") as csvfile:
                 writer = csv.writer(csvfile)
+                for row in results:
+                    writer.writerow(row)
+        elif str(filename).endswith(".csv.gz"):
+            # `gzip.open` defaults to 9 (max compression) whereas the default
+            # speed/compression tradeoff in the command line tool is 6
+            with gzip.open(filename, "wt", newline="", compresslevel=6) as gzfile:
+                writer = csv.writer(gzfile)
                 for row in results:
                     writer.writerow(row)
         else:

--- a/cohortextractor/emis_backend.py
+++ b/cohortextractor/emis_backend.py
@@ -54,7 +54,8 @@ class EMISBackend:
             if query_args.get("returning") == "pseudo_id":
                 query_args["column_type"] = "str"
 
-    def to_csv(self, filename):
+    def to_file(self, filename):
+        assert str(filename).endswith(".csv")
         result = self.execute_query()
 
         # Wrap the results stream in a function which captures unique IDs,

--- a/cohortextractor/expectation_generators.py
+++ b/cohortextractor/expectation_generators.py
@@ -103,9 +103,6 @@ def generate(population, **kwargs):
         category_labels = dict(zip(category_ids, ratios.keys()))
         df = df.replace({"category": category_labels})
         df["category"] = df["category"].astype("category")
-        # Add empty string as a category to support missing values
-        if "" not in df["category"].cat.categories:
-            df["category"].cat.add_categories(new_categories=[""], inplace=True)
 
     int_ = kwargs.pop("int", None)
     if int_:
@@ -159,7 +156,7 @@ def set_empty_values(df, row_selection):
         # get converted to strings during the CSV generation, the nulls become
         # empty strings as expected.
         "date": None,
-        "category": "",
+        "category": None,
     }
     for column in df.columns:
         df.loc[row_selection, column] = empty_values.get(column, "")

--- a/cohortextractor/pandas_utils.py
+++ b/cohortextractor/pandas_utils.py
@@ -1,18 +1,16 @@
-from pathlib import Path
-
 import pandas
 
 
 def dataframe_to_file(df, filename):
-    extension = Path(filename).suffix.lstrip(".")
-    if extension == "csv":
+    filename = str(filename)
+    if filename.endswith(".csv"):
         df.to_csv(filename, index=False)
-    elif extension == "feather":
+    elif filename.endswith(".feather"):
         df.to_feather(filename)
-    elif extension == "dta":
+    elif filename.endswith(".dta"):
         df.to_stata(filename, write_index=False)
     else:
-        raise RuntimeError(f"Unsupported extension: {extension}")
+        raise RuntimeError(f"Unsupported file format: {filename}")
 
 
 def dataframe_from_rows(covariate_definitions, rows):

--- a/cohortextractor/pandas_utils.py
+++ b/cohortextractor/pandas_utils.py
@@ -3,11 +3,11 @@ import pandas
 
 def dataframe_to_file(df, filename):
     filename = str(filename)
-    if filename.endswith(".csv"):
+    if filename.endswith(".csv") or filename.endswith(".csv.gz"):
         df.to_csv(filename, index=False)
     elif filename.endswith(".feather"):
         df.to_feather(filename)
-    elif filename.endswith(".dta"):
+    elif filename.endswith(".dta") or filename.endswith(".dta.gz"):
         df.to_stata(filename, write_index=False)
     else:
         raise RuntimeError(f"Unsupported file format: {filename}")

--- a/cohortextractor/pandas_utils.py
+++ b/cohortextractor/pandas_utils.py
@@ -1,0 +1,111 @@
+from pathlib import Path
+
+import pandas
+
+
+def dataframe_to_file(df, filename):
+    extension = Path(filename).suffix.lstrip(".")
+    if extension == "csv":
+        df.to_csv(filename, index=False)
+    elif extension == "feather":
+        df.to_feather(filename)
+    elif extension == "dta":
+        df.to_stata(filename, write_index=False)
+    else:
+        raise RuntimeError(f"Unsupported extension: {extension}")
+
+
+def dataframe_from_rows(covariate_definitions, rows):
+    """
+    Create a DataFrame from an iterator of rows
+    """
+    convertors = {
+        name: get_pandas_convertor(funcname, **kwargs)
+        for name, (funcname, kwargs) in covariate_definitions.items()
+    }
+    # `patient_id` isn't included in `covariate_definitions` so we need to add
+    # it manually
+    convertors["patient_id"] = identity
+
+    # First row is expected to be header row
+    headers = next(rows)
+    convertor_funcs = [convertors[column] for column in headers]
+
+    def convert_row(row):
+        return [convertor(value) for (convertor, value) in zip(convertor_funcs, row)]
+
+    data = map(convert_row, rows)
+    df = pandas.DataFrame(data, columns=headers)
+    # Change categorical columns from arrays of ints to proper Pandas
+    # Categorical objects
+    for column in headers:
+        convertor = convertors[column]
+        if isinstance(convertor, Categoriser):
+            categorical = pandas.Categorical.from_codes(
+                df[column], categories=convertor.get_categories(), ordered=False
+            )
+            df[column] = categorical
+    return df
+
+
+def get_pandas_convertor(funcname, column_type=None, returning=None, **kwargs):
+    # Awkward workaround: IMD is in fact an int, but it comes to us
+    # rounded to nearest hundred which makes it act a bit more like a
+    # categorical variable for the purposes of dummy data generation so
+    # we pretend that's what it is here. Similarly, rural/urban
+    # classification is as int in datatype terms but is conceptually
+    # categorical, so possibly we need a categorical int type to handle
+    # these.
+    if returning in (
+        "index_of_multiple_deprivation",
+        "rural_urban_classification",
+    ):
+        return Categoriser()
+
+    if column_type == "date":
+        return to_datetime
+    elif column_type == "bool":
+        return bool
+    elif column_type == "str":
+        return Categoriser()
+    elif column_type in ("int", "float"):
+        return identity
+    else:
+        raise ValueError(f"Unable to impute Pandas type for {column_type} ({funcname})")
+
+
+class Categoriser(dict):
+
+    counter = 0
+
+    __call__ = dict.__getitem__
+
+    def __missing__(self, value):
+        if value:
+            index = self.counter
+            self.counter += 1
+        else:
+            index = -1
+        self[value] = index
+        return index
+
+    def get_categories(self):
+        enumerated = sorted((index, key) for (key, index) in self.items())
+        return [key for (index, key) in enumerated if index > -1]
+
+
+def identity(value):
+    return value
+
+
+def memoize(fn):
+    class cache(dict):
+        def __missing__(self, key):
+            value = fn(key)
+            self[key] = value
+            return value
+
+    return cache().__getitem__
+
+
+to_datetime = memoize(pandas.to_datetime)

--- a/cohortextractor/study_definition.py
+++ b/cohortextractor/study_definition.py
@@ -67,7 +67,8 @@ class StudyDefinition:
                 temporary_database=self.temporary_database,
             )
 
-    def to_csv(self, filename, expectations_population=False, **kwargs):
+    def to_file(self, filename, expectations_population=False, **kwargs):
+        assert str(filename).endswith(".csv")
         if expectations_population:
             df = self.make_df_from_expectations(expectations_population)
             # Add a patient ID - a randomly generated integer from an
@@ -78,7 +79,7 @@ class StudyDefinition:
             df.to_csv(filename, index=False)
         else:
             self.assert_backend_is_configured()
-            self.backend.to_csv(filename, **kwargs)
+            self.backend.to_file(filename, **kwargs)
 
     def csv_to_df(self, csv_name):
         return pd.read_csv(

--- a/cohortextractor/study_definition.py
+++ b/cohortextractor/study_definition.py
@@ -12,6 +12,7 @@ from .date_expressions import (
     validate_date,
 )
 from .expectation_generators import generate
+from .pandas_utils import dataframe_to_file
 from .process_covariate_definitions import process_covariate_definitions
 
 
@@ -68,7 +69,6 @@ class StudyDefinition:
             )
 
     def to_file(self, filename, expectations_population=False, **kwargs):
-        assert str(filename).endswith(".csv")
         if expectations_population:
             df = self.make_df_from_expectations(expectations_population)
             # Add a patient ID - a randomly generated integer from an
@@ -76,7 +76,7 @@ class StudyDefinition:
             df["patient_id"] = default_rng().choice(
                 (len(df) * 10), size=len(df), replace=False
             )
-            df.to_csv(filename, index=False)
+            dataframe_to_file(df, filename)
         else:
             self.assert_backend_is_configured()
             self.backend.to_file(filename, **kwargs)

--- a/cohortextractor/tpp_backend.py
+++ b/cohortextractor/tpp_backend.py
@@ -107,9 +107,11 @@ class TPPBackend:
         os.rename(temp_filename, filename)
 
     def _get_temp_filename(self, filename):
-        root, extension = os.path.splitext(filename)
+        root, name = os.path.split(filename)
+        # Need to handle multiple extensions e.g. csv.gz to can't use `splitext`
+        base, sep, extensions = name.partition(".")
         timestamp = datetime.datetime.now().strftime("%Y%m%d-%H%M%S")
-        return f"{root}.partial.{timestamp}{extension}"
+        return os.path.join(root, f"{base}.partial.{timestamp}{sep}{extensions}")
 
     def to_dicts(self):
         result = self.execute_queries(self.queries)

--- a/cohortextractor/tpp_backend.py
+++ b/cohortextractor/tpp_backend.py
@@ -1,6 +1,7 @@
 import csv
 import datetime
 import enum
+import gzip
 import hashlib
 import os
 import re
@@ -84,9 +85,16 @@ class TPPBackend:
 
         # Special handling for CSV as we can stream this directly to disk
         # without building a dataframe in memory
-        if str(temp_filename).endswith(".csv"):
+        if temp_filename.endswith(".csv"):
             with open(temp_filename, "w", newline="") as csvfile:
                 writer = csv.writer(csvfile)
+                for row in results:
+                    writer.writerow(row)
+        elif temp_filename.endswith(".csv.gz"):
+            # `gzip.open` defaults to 9 (max compression) whereas the default
+            # speed/compression tradeoff in the command line tool is 6
+            with gzip.open(temp_filename, "wt", newline="", compresslevel=6) as gzfile:
+                writer = csv.writer(gzfile)
                 for row in results:
                     writer.writerow(row)
         else:

--- a/cohortextractor/tpp_backend.py
+++ b/cohortextractor/tpp_backend.py
@@ -30,7 +30,8 @@ class TPPBackend:
         self.next_temp_table_id = 1
         self.queries = self.get_queries(self.covariate_definitions)
 
-    def to_csv(self, filename):
+    def to_file(self, filename):
+        assert str(filename).endswith(".csv")
         queries = list(self.queries)
         # If we have a temporary database available we write results to a table
         # there, download them, and then delete the table. This allows us to

--- a/requirements.txt
+++ b/requirements.txt
@@ -56,6 +56,8 @@ isort==5.7.0
     # via -r requirements.in
 kiwisolver==1.2.0
     # via matplotlib
+lz4==3.1.3
+    # via opensafely-cohort-extractor
 matplotlib==3.2.1
     # via seaborn
 mccabe==0.6.1
@@ -70,6 +72,7 @@ numpy==1.18.1
     # via
     #   matplotlib
     #   pandas
+    #   pyarrow
     #   scipy
     #   seaborn
 opensafely-jobrunner==2.1.6
@@ -96,6 +99,8 @@ py==1.8.1
     # via
     #   pytest
     #   retry
+pyarrow==3.0.0
+    # via opensafely-cohort-extractor
 pycodestyle==2.6.0
     # via flake8
 pycparser==2.20

--- a/setup.py
+++ b/setup.py
@@ -14,10 +14,12 @@ setup(
     author_email="tech@opensafely.org",
     python_requires=">=3.7",
     install_requires=[
+        "lz4",
         "opensafely-jobrunner>=2.0,<3.0",
         "pandas",
         "presto-python-client",
         "prettytable",
+        "pyarrow",
         "pyyaml",
         "requests",
         "requests-pkcs12",

--- a/tests/dashboards/test_vaccinations.py
+++ b/tests/dashboards/test_vaccinations.py
@@ -111,7 +111,7 @@ def test_study_definition(tmp_path):
             "mmr_2",
         ],
     )
-    study.to_csv(tmp_path / "test.csv")
+    study.to_file(tmp_path / "test.csv")
     with open(tmp_path / "test.csv", newline="") as f:
         reader = csv.DictReader(f)
         results = list(reader)
@@ -200,7 +200,7 @@ def test_study_definition_dummy_data(tmp_path):
             "mmr_2",
         ],
     )
-    study.to_csv(tmp_path / "dummy.csv", expectations_population=1000)
+    study.to_file(tmp_path / "dummy.csv", expectations_population=1000)
     with open(tmp_path / "dummy.csv", newline="") as f:
         reader = csv.DictReader(f)
         results = list(reader)

--- a/tests/test_emis_backend.py
+++ b/tests/test_emis_backend.py
@@ -68,8 +68,8 @@ def test_minimal_study_to_csv():
     session.add_all([patient_1, patient_2])
     session.commit()
     study = StudyDefinition(population=patients.all(), sex=patients.sex())
-    with tempfile.NamedTemporaryFile(mode="w+") as f:
-        study.to_csv(f.name)
+    with tempfile.NamedTemporaryFile(mode="w+", suffix=".csv") as f:
+        study.to_file(f.name)
         results = list(csv.DictReader(f))
         assert results == [
             {"patient_id": "0", "sex": "M"},
@@ -1563,8 +1563,8 @@ def test_duplicate_id_checking():
     with pytest.raises(RuntimeError):
         study.to_dicts()
     with pytest.raises(RuntimeError):
-        with tempfile.NamedTemporaryFile(mode="w+") as f:
-            study.to_csv(f.name)
+        with tempfile.NamedTemporaryFile(mode="w+", suffix=".csv") as f:
+            study.to_file(f.name)
 
 
 def test_column_name_clashes_produce_errors():

--- a/tests/test_emis_backend.py
+++ b/tests/test_emis_backend.py
@@ -65,11 +65,15 @@ def delete_temporary_tables():
 @pytest.mark.parametrize("format", ["csv", "feather", "dta"])
 def test_minimal_study_to_file(tmp_path, format):
     session = make_session()
-    patient_1 = Patient(date_of_birth="1900-01-01", gender=1, hashed_organisation="abc")
-    patient_2 = Patient(date_of_birth="1900-01-01", gender=2, hashed_organisation="abc")
+    patient_1 = Patient(date_of_birth="1980-01-01", gender=1, hashed_organisation="abc")
+    patient_2 = Patient(date_of_birth="1965-01-01", gender=2, hashed_organisation="abc")
     session.add_all([patient_1, patient_2])
     session.commit()
-    study = StudyDefinition(population=patients.all(), sex=patients.sex())
+    study = StudyDefinition(
+        population=patients.all(),
+        sex=patients.sex(),
+        age=patients.age_as_of("2020-01-01"),
+    )
     filename = tmp_path / f"test.{format}"
     study.to_file(filename)
     cast = lambda x: x  # noqa
@@ -82,8 +86,8 @@ def test_minimal_study_to_file(tmp_path, format):
     elif format == "dta":
         results = pandas.read_stata(filename).to_dict("records")
     assert results == [
-        {"patient_id": cast(0), "sex": "M"},
-        {"patient_id": cast(1), "sex": "F"},
+        {"patient_id": cast(0), "sex": "M", "age": cast(40)},
+        {"patient_id": cast(1), "sex": "F", "age": cast(55)},
     ]
 
 

--- a/tests/test_pandas_utils.py
+++ b/tests/test_pandas_utils.py
@@ -1,0 +1,85 @@
+import math
+
+from pandas import NaT, Timestamp
+
+from cohortextractor.pandas_utils import dataframe_from_rows
+
+
+def test_dataframe_from_rows():
+    rows = [
+        ("patient_id", "age", "sex", "bmi", "stp", "date_admitted", "date_died"),
+        (1, 20, "M", 18.5, "STP1", "2018-08-01", "2020-05"),
+        (2, 38, "F", None, "STP2", "2019-12-12", "2020-06"),
+        (3, 65, "M", 0, "STP2", "", "2020-07"),
+        (4, 42, "F", 17.8, "", "2020-04-10", "2020-08"),
+        (5, 18, "M", 26.2, "STP3", "2020-06-20", ""),
+    ]
+    covariate_definitions = {
+        "population": ("satisfying", {"column_type": "bool"}),
+        "age": ("age_as_of", {"column_type": "int"}),
+        "sex": ("sex", {"column_type": "str"}),
+        "bmi": ("bmi", {"column_type": "float"}),
+        "stp": ("practice_as_of", {"column_type": "str"}),
+        "date_admitted": ("admitted_to_hospital", {"column_type": "date"}),
+        "date_died": ("with_death_recorded_in_cpns", {"column_type": "date"}),
+    }
+    df = dataframe_from_rows(covariate_definitions, iter(rows))
+
+    expected = [
+        {
+            "age": 20,
+            "bmi": 18.5,
+            "date_admitted": Timestamp("2018-08-01 00:00:00"),
+            "date_died": Timestamp("2020-05-01 00:00:00"),
+            "patient_id": 1,
+            "sex": "M",
+            "stp": "STP1",
+        },
+        {
+            "age": 38,
+            "bmi": None,
+            "date_admitted": Timestamp("2019-12-12 00:00:00"),
+            "date_died": Timestamp("2020-06-01 00:00:00"),
+            "patient_id": 2,
+            "sex": "F",
+            "stp": "STP2",
+        },
+        {
+            "age": 65,
+            "bmi": 0.0,
+            "date_admitted": NaT,
+            "date_died": Timestamp("2020-07-01 00:00:00"),
+            "patient_id": 3,
+            "sex": "M",
+            "stp": "STP2",
+        },
+        {
+            "age": 42,
+            "bmi": 17.8,
+            "date_admitted": Timestamp("2020-04-10 00:00:00"),
+            "date_died": Timestamp("2020-08-01 00:00:00"),
+            "patient_id": 4,
+            "sex": "F",
+            "stp": None,
+        },
+        {
+            "age": 18,
+            "bmi": 26.2,
+            "date_admitted": Timestamp("2020-06-20 00:00:00"),
+            "date_died": NaT,
+            "patient_id": 5,
+            "sex": "M",
+            "stp": "STP3",
+        },
+    ]
+
+    # Faff, we can't do equality checks with NaN values so we have to convert
+    # them to None
+    records = [
+        {
+            k: v if not (type(v) is float and math.isnan(v)) else None
+            for (k, v) in record.items()
+        }
+        for record in df.to_dict("record")
+    ]
+    assert records == expected

--- a/tests/test_pandas_utils.py
+++ b/tests/test_pandas_utils.py
@@ -1,5 +1,7 @@
 import math
 
+import numpy
+import pandas
 from pandas import NaT, Timestamp
 
 from cohortextractor.pandas_utils import dataframe_from_rows
@@ -27,49 +29,49 @@ def test_dataframe_from_rows():
 
     expected = [
         {
+            "patient_id": 1,
             "age": 20,
+            "sex": "M",
             "bmi": 18.5,
+            "stp": "STP1",
             "date_admitted": Timestamp("2018-08-01 00:00:00"),
             "date_died": Timestamp("2020-05-01 00:00:00"),
-            "patient_id": 1,
-            "sex": "M",
-            "stp": "STP1",
         },
         {
+            "patient_id": 2,
             "age": 38,
+            "sex": "F",
             "bmi": None,
+            "stp": "STP2",
             "date_admitted": Timestamp("2019-12-12 00:00:00"),
             "date_died": Timestamp("2020-06-01 00:00:00"),
-            "patient_id": 2,
-            "sex": "F",
-            "stp": "STP2",
         },
         {
+            "patient_id": 3,
             "age": 65,
+            "sex": "M",
             "bmi": 0.0,
+            "stp": "STP2",
             "date_admitted": NaT,
             "date_died": Timestamp("2020-07-01 00:00:00"),
-            "patient_id": 3,
-            "sex": "M",
-            "stp": "STP2",
         },
         {
+            "patient_id": 4,
             "age": 42,
+            "sex": "F",
             "bmi": 17.8,
+            "stp": None,
             "date_admitted": Timestamp("2020-04-10 00:00:00"),
             "date_died": Timestamp("2020-08-01 00:00:00"),
-            "patient_id": 4,
-            "sex": "F",
-            "stp": None,
         },
         {
+            "patient_id": 5,
             "age": 18,
+            "sex": "M",
             "bmi": 26.2,
+            "stp": "STP3",
             "date_admitted": Timestamp("2020-06-20 00:00:00"),
             "date_died": NaT,
-            "patient_id": 5,
-            "sex": "M",
-            "stp": "STP3",
         },
     ]
 
@@ -83,3 +85,10 @@ def test_dataframe_from_rows():
         for record in df.to_dict("record")
     ]
     assert records == expected
+    assert df.patient_id.dtype == int
+    assert df.age.dtype == int
+    assert type(df.sex.dtype) == pandas.CategoricalDtype
+    assert df.bmi.dtype == float
+    assert type(df.stp.dtype) == pandas.CategoricalDtype
+    assert df.date_admitted.dtype == numpy.dtype("datetime64[ns]")
+    assert df.date_died.dtype == numpy.dtype("datetime64[ns]")

--- a/tests/test_smoketest.py
+++ b/tests/test_smoketest.py
@@ -7,10 +7,13 @@ import os
 import subprocess
 import sys
 
+import pytest
+
 import cohortextractor
 
 
-def test_smoketest(tmp_path):
+@pytest.mark.parametrize("format", ["csv", "feather", "dta"])
+def test_smoketest(tmp_path, format):
     _cohortextractor(
         "generate_cohort",
         "--expectations-population",
@@ -19,11 +22,15 @@ def test_smoketest(tmp_path):
         "2020-01-01 to 2020-04-01 by month",
         "--output-dir",
         tmp_path,
+        "--output-format",
+        format,
     )
     _cohortextractor(
         "generate_measures",
         "--output-dir",
         tmp_path,
+        "--output-format",
+        format,
     )
     # liver_disease_by_stp
     with open(tmp_path / "measure_liver_disease_by_stp.csv") as f:

--- a/tests/test_smoketest.py
+++ b/tests/test_smoketest.py
@@ -29,8 +29,6 @@ def test_smoketest(tmp_path, format):
         "generate_measures",
         "--output-dir",
         tmp_path,
-        "--output-format",
-        format,
     )
     # liver_disease_by_stp
     with open(tmp_path / "measure_liver_disease_by_stp.csv") as f:

--- a/tests/test_smoketest.py
+++ b/tests/test_smoketest.py
@@ -12,7 +12,7 @@ import pytest
 import cohortextractor
 
 
-@pytest.mark.parametrize("format", ["csv", "feather", "dta"])
+@pytest.mark.parametrize("format", ["csv", "csv.gz", "feather", "dta", "dta.gz"])
 def test_smoketest(tmp_path, format):
     _cohortextractor(
         "generate_cohort",

--- a/tests/test_study_definition.py
+++ b/tests/test_study_definition.py
@@ -30,7 +30,7 @@ def test_create_dummy_data_works_without_database_url(tmp_path, monkeypatch):
         ),
     )
     filename = tmp_path / "dummy_data.csv"
-    study.to_csv(filename, expectations_population=10)
+    study.to_file(filename, expectations_population=10)
     with open(filename) as f:
         results = list(csv.DictReader(f))
     assert len(results) == 10
@@ -49,7 +49,7 @@ def test_export_data_without_database_url_raises_error(tmp_path, monkeypatch):
         ),
     )
     with pytest.raises(RuntimeError):
-        study.to_csv(tmp_path / "dummy_data.csv")
+        study.to_file(tmp_path / "dummy_data.csv")
 
 
 def test_unrecognised_database_url_raises_error(monkeypatch):
@@ -94,7 +94,7 @@ def test_drivers_not_accidentally_imported(tmp_path):
                 }
             ),
         )
-        study.to_csv("/dev/null", expectations_population=10)
+        study.to_file("TMP_PATH/dummy.csv", expectations_population=10)
         pyodbc = "yes" if "pyodbc" in sys.modules else "no"
         ctds = "yes" if "ctds" in sys.modules else "no"
         print(f"pyodbc: {pyodbc}, ctds: {ctds}")
@@ -103,6 +103,7 @@ def test_drivers_not_accidentally_imported(tmp_path):
     # function definition line and stripping the indentation
     source = inspect.getsource(test_script).splitlines()[1:]
     source = textwrap.dedent("\n".join(source))
+    source = source.replace("TMP_PATH", str(tmp_path))
     result = subprocess.check_output([sys.executable, "-c", source]).strip()
     assert result == b"pyodbc: no, ctds: no"
 

--- a/tests/test_tpp_backend.py
+++ b/tests/test_tpp_backend.py
@@ -102,7 +102,7 @@ def test_minimal_study_to_csv(tmp_path):
     session.add_all([patient_1, patient_2])
     session.commit()
     study = StudyDefinition(population=patients.all(), sex=patients.sex())
-    study.to_csv(tmp_path / "test.csv")
+    study.to_file(tmp_path / "test.csv")
     with open(tmp_path / "test.csv") as f:
         results = list(csv.DictReader(f))
     assert results == [
@@ -117,7 +117,7 @@ def test_sql_error_propagates(tmp_path):
     # at the end
     study.backend.queries[-1] = "SELECT Foo FROM Bar"
     with pytest.raises(Exception) as excinfo:
-        study.to_csv(tmp_path / "test.csv")
+        study.to_file(tmp_path / "test.csv")
     assert "Invalid object name 'Bar'" in str(excinfo.value)
 
 
@@ -1601,7 +1601,7 @@ def test_duplicate_id_checking(tmp_path):
     with pytest.raises(RuntimeError):
         study.to_dicts()
     with pytest.raises(RuntimeError):
-        study.to_csv(tmp_path / "test.csv")
+        study.to_file(tmp_path / "test.csv")
     # Check that we don't produce a normal output file but we do leave a
     # partial file
     assert not os.path.exists(tmp_path / "test.csv")
@@ -2900,7 +2900,7 @@ def test_temporary_database_happy_path(tmp_path, monkeypatch):
         age=patients.age_as_of("1990-01-01"),
     )
     initial_temporary_tables = _list_table_in_db(session, temporary_database)
-    study.to_csv(tmp_path / "test.csv")
+    study.to_file(tmp_path / "test.csv")
     with open(tmp_path / "test.csv") as f:
         results = list(csv.DictReader(f))
     assert_results(results, sex=["M", "F"], age=["30", "10"])
@@ -2931,7 +2931,7 @@ def test_temporary_database_with_failure(tmp_path, monkeypatch):
     with patch("cohortextractor.tpp_backend.mssql_fetch_table") as mssql_fetch_table:
         mssql_fetch_table.side_effect = ValueError("deliberate error")
         with pytest.raises(ValueError, match="deliberate error"):
-            study.to_csv(tmp_path / "fail.csv")
+            study.to_file(tmp_path / "fail.csv")
     # Check that we've created one extra temporary table
     temporary_tables = _list_table_in_db(session, temporary_database)
     assert len(set(temporary_tables) - set(initial_temporary_tables)) == 1
@@ -2942,7 +2942,7 @@ def test_temporary_database_with_failure(tmp_path, monkeypatch):
     # Now try making a new study with the same definition, downloading again
     # and check we have correct results
     new_study = StudyDefinition(**study_args)
-    new_study.to_csv(tmp_path / "test.csv")
+    new_study.to_file(tmp_path / "test.csv")
     with open(tmp_path / "test.csv") as f:
         results = list(csv.DictReader(f))
     assert_results(results, sex=["M", "F"], age=["40", "20"])

--- a/tests/test_tpp_backend.py
+++ b/tests/test_tpp_backend.py
@@ -2928,8 +2928,8 @@ def test_temporary_database_with_failure(tmp_path, monkeypatch):
     study = StudyDefinition(**study_args)
     initial_temporary_tables = _list_table_in_db(session, temporary_database)
     # Trigger error during data download process
-    with patch("cohortextractor.mssql_utils.csv") as csv_module:
-        csv_module.writer.side_effect = ValueError("deliberate error")
+    with patch("cohortextractor.tpp_backend.mssql_fetch_table") as mssql_fetch_table:
+        mssql_fetch_table.side_effect = ValueError("deliberate error")
         with pytest.raises(ValueError, match="deliberate error"):
             study.to_csv(tmp_path / "fail.csv")
     # Check that we've created one extra temporary table

--- a/tests/test_tpp_backend.py
+++ b/tests/test_tpp_backend.py
@@ -99,11 +99,15 @@ def setup_function(function):
 @pytest.mark.parametrize("format", ["csv", "feather", "dta"])
 def test_minimal_study_to_file(tmp_path, format):
     session = make_session()
-    patient_1 = Patient(DateOfBirth="1900-01-01", Sex="M")
-    patient_2 = Patient(DateOfBirth="1900-01-01", Sex="F")
+    patient_1 = Patient(DateOfBirth="1980-01-01", Sex="M")
+    patient_2 = Patient(DateOfBirth="1965-01-01", Sex="F")
     session.add_all([patient_1, patient_2])
     session.commit()
-    study = StudyDefinition(population=patients.all(), sex=patients.sex())
+    study = StudyDefinition(
+        population=patients.all(),
+        sex=patients.sex(),
+        age=patients.age_as_of("2020-01-01"),
+    )
     filename = tmp_path / f"test.{format}"
     study.to_file(filename)
     cast = lambda x: x  # noqa
@@ -116,8 +120,8 @@ def test_minimal_study_to_file(tmp_path, format):
     elif format == "dta":
         results = pandas.read_stata(filename).to_dict("records")
     assert results == [
-        {"patient_id": cast(patient_1.Patient_ID), "sex": "M"},
-        {"patient_id": cast(patient_2.Patient_ID), "sex": "F"},
+        {"patient_id": cast(patient_1.Patient_ID), "sex": "M", "age": cast(40)},
+        {"patient_id": cast(patient_2.Patient_ID), "sex": "F", "age": cast(55)},
     ]
 
 


### PR DESCRIPTION
This adds an `--output-format` argument to the `generate_cohort` command:
```
  --output-format {csv,csv.gz,feather,dta,dta.gz}
                        Output file format: csv (default), csv.gz, feather, dta, dta.gz
```

Note that measures are still always generated in CSV. It would be possible the teach the `generate_measures` command to respect this flag as well, but it's more work and the necessity isn't as great here as measures files are so much smaller.

Note also that this while this should reduce memory consumption for analysis scripts, it will increase it for the cohortextractor as we now have to build an entire dataframe in memory rather than streaming directly to disk as we did with CSV. I have attempted to mitigate this by converting strings to categories on the fly instead of at the end, but until we try it for real on the EMIS backend it's impossible to say whether it's going to be a problem or not.

Closes #503