### PR TITLE
fix: Stop writing output to temporary filename first

### DIFF
--- a/tests/test_tpp_backend.py
+++ b/tests/test_tpp_backend.py
@@ -1,6 +1,5 @@
 # -*- coding: utf-8 -*-
 import csv
-import glob
 import gzip
 import os
 import subprocess
@@ -1621,11 +1620,16 @@ def test_duplicate_id_checking(tmp_path):
         study.to_dicts()
     with pytest.raises(RuntimeError):
         study.to_file(tmp_path / "test.csv")
-    # Check that we don't produce a normal output file but we do leave a
-    # partial file
-    assert not os.path.exists(tmp_path / "test.csv")
-    partial_files = glob.glob(f"{tmp_path}/test.partial.*.csv")
-    assert len(partial_files) == 1
+    # Check that we still produce an output file with the duplicates in
+    with open(tmp_path / "test.csv") as f:
+        output = list(csv.DictReader(f))
+    expected = [
+        {"patient_id": "1", "foo": "1"},
+        {"patient_id": "1", "foo": "4"},
+        {"patient_id": "2", "foo": "2"},
+        {"patient_id": "3", "foo": "3"},
+    ]
+    assert output == expected
 
 
 def test_using_expression_in_population_definition():


### PR DESCRIPTION
In the old days cohortextractor was run manually and it was important
that we didn't create files that looked like they were successful
outputs when they in fact had errors. We did this by writing outputs to
temporary filenames and then renaming them on success or, on error,
leaving them under their temporary names for debugging purposes.

Now that the job-runner infrastructure explicitly tracks exit codes we
don't have the same problem as it's impossible to accidentally use the
output of a failed job in another action. So using temporary files
brings unnecessary complexity. In fact, it's now actively harmful
because in the case that a cohort extraction fails the file produced
doesn't have the expected name and so doesn't match the output pattern
and is never copied out of the container. This means partially completed
output files aren't available for debugging, which is annoying.