### PR TITLE
fix: Extend "prefix matching" to primary diagnosis field

### DIFF
--- a/cohortextractor/patients.py
+++ b/cohortextractor/patients.py
@@ -1904,8 +1904,12 @@ def admitted_to_hospital(
         date_format: a string detailing the format of the dates to be returned. It can be `YYYY-MM-DD`,
             `YYYY-MM` or `YYYY` and wherever possible the least disclosive data should be returned. i.e returning
             only year is less disclosive than a date with day, month and year.
-        with_these_diagnoses: icd10 codes to match against any diagnosis
-        with_these_primary_diagnoses: icd10 codes to match against the primary diagnosis
+        with_these_diagnoses: icd10 codes to match against any diagnosis (note
+            this uses **prefix** matching so a code like `J12` will match
+            `J120`, `J121` etc.)
+        with_these_primary_diagnoses: icd10 codes to match against the primary
+            diagnosis note this uses **prefix** matching so a code like `J12`
+            will match `J120`, `J121` etc.)
         with_these_procedures: opcs4 codes to match against the procedure
         with_admission_method: string or list of strings to match against
         with_source_of_admission: string or list of strings to match against

--- a/cohortextractor/tpp_backend.py
+++ b/cohortextractor/tpp_backend.py
@@ -1962,8 +1962,13 @@ class TPPBackend:
 
         if with_these_primary_diagnoses:
             assert with_these_primary_diagnoses.system == "icd10"
-            codes_sql = codelist_to_sql(with_these_primary_diagnoses)
-            conditions.append(f"APCS_Der.Spell_Primary_Diagnosis IN ({codes_sql})")
+            fragments = [
+                f"APCS_Der.Spell_Primary_Diagnosis LIKE {pattern} ESCAPE '\\'"
+                for pattern in codelist_to_like_patterns(
+                    with_these_primary_diagnoses, prefix="", suffix="%"
+                )
+            ]
+            conditions.append("(" + " OR ".join(fragments) + ")")
 
         if with_these_diagnoses:
             assert with_these_diagnoses.system == "icd10"

--- a/tests/test_tpp_backend.py
+++ b/tests/test_tpp_backend.py
@@ -2883,6 +2883,10 @@ def test_patients_admitted_to_hospital():
             with_admission_method=["11", "99"],
             returning="days_in_critical_care",
         ),
+        primary_diagnosis_prefix=patients.admitted_to_hospital(
+            returning="binary_flag",
+            with_these_primary_diagnoses=codelist(["AAA"], "icd10"),
+        ),
     )
 
     assert_results(
@@ -2903,6 +2907,7 @@ def test_patients_admitted_to_hospital():
         last_primary_diagnosis=["", "", "CCCC", "FFFF"],
         discharge_dest=["", "11", "99", ""],
         critical_care_days=["", "3", "", "5"],
+        primary_diagnosis_prefix=["0", "1", "0", "0"],
     )
 
 


### PR DESCRIPTION
When querying the Diagnoses field in the APCS data we use prefix
matching so that searching for the code `J12` will also return the code
`J120`, `J121` etc.

I initially thought this was a bug but there turns out to be a test for
precisely this behaviour. It also makes clinical sense given the
hierarchical nature of ICD-10 codes.

But we weren't doing this for the Primary Diagnosis field which is a
confusing inconsistency. It's particularly problematic with the APCS data
which seems to represent three characters codes by padding them with an
X to make them four character. As the resulting codes were not valid
ICD-10 codes there was no way to represent them in the codelist builder
and therefore. Using prefix matching sidesteps this problem.

This is possibly a slightly controversial approach; see in particular
the discussion at:
https://github.com/opensafely-core/cohort-extractor/issues/512#issuecomment-812027119

Closes #512