### PR TITLE
Better document the with_these_clinical_events function

### DIFF
--- a/cohortextractor/patients.py
+++ b/cohortextractor/patients.py
@@ -568,7 +568,7 @@ def with_these_clinical_events(
         find_first_match_in_period: a boolean indicating if any returned date, code, category, or numeric value
             should be based on the first match in the period.
         find_last_match_in_period: a boolean indicating if any returned date, code, category, or numeric value
-            should be based on the last match in the period.
+            should be based on the last match in the period. This is the default behaviour.
         include_date_of_match: a boolean indicating if an extra column should be included in the output.
             The default value is `False`.
         date_format: a string detailing the format of the dates to be returned. It can be `YYYY-MM-DD`,

--- a/cohortextractor/patients.py
+++ b/cohortextractor/patients.py
@@ -567,8 +567,10 @@ def with_these_clinical_events(
 
         find_first_match_in_period: a boolean indicating if any returned date, code, category, or numeric value
             should be based on the first match in the period.
+            If several matches compare equal, then their IDs are used to break the tie.
         find_last_match_in_period: a boolean indicating if any returned date, code, category, or numeric value
             should be based on the last match in the period. This is the default behaviour.
+            If several matches compare equal, then their IDs are used to break the tie.
         include_date_of_match: a boolean indicating if an extra column should be included in the output.
             The default value is `False`.
         date_format: a string detailing the format of the dates to be returned. It can be `YYYY-MM-DD`,


### PR DESCRIPTION
For context, see opensafely/SRO-Measures#10. I've attempted to clarify what the default behaviour is, which is implicit in the kwargs, and also what happens when there is a tie-break.