### PR TITLE
fix: Don't leak internal 9999-21-31 deregistration date

### DIFF
--- a/cohortextractor/tpp_backend.py
+++ b/cohortextractor/tpp_backend.py
@@ -1335,7 +1335,9 @@ class TPPBackend:
             max_date = "3000-01-01"
         if min_date is None:
             min_date = "1900-01-01"
-        date_condition, date_joins = self.get_date_condition("t", "t.end_date", between)
+        date_condition, date_joins = self.get_date_condition(
+            "t", "t.end_date", (min_date, max_date)
+        )
         return f"""
         SELECT
           t.Patient_id,

--- a/tests/test_tpp_backend.py
+++ b/tests/test_tpp_backend.py
@@ -2741,8 +2741,16 @@ def test_patients_date_deregistered_from_all_supported_practices():
             on_or_before="2018-02-01",
             date_format="YYYY-MM",
         ),
+        dereg_date_2=patients.date_deregistered_from_all_supported_practices(
+            on_or_after="2015-01-01",
+            date_format="YYYY-MM",
+        ),
     )
-    assert_results(study.to_dicts(), dereg_date=["", "", "2017-10"])
+    assert_results(
+        study.to_dicts(),
+        dereg_date=["", "", "2017-10"],
+        dereg_date_2=["", "2020-01", "2017-10"],
+    )
 
 
 def test_patients_admitted_to_hospital():


### PR DESCRIPTION
Currently active registrations are recorded as having an end date of
9999-12-31. This is an internal detail we shouldn't leak: we should
instead return a deregistration date of NULL for currently registered
patients. Aside from being inelegant, this date can't be represented as
a Pandas timestamp and so it causes binary exports to fail.

We already attempted to do the right thing here, but the code was buggy
and the tests inadequate.

Closes #500