### PR TITLE
Fix bug with minimum_of/maximum_of queries

### DIFF
--- a/cohortextractor/emis_backend.py
+++ b/cohortextractor/emis_backend.py
@@ -313,7 +313,7 @@ class EMISBackend:
             # value for the column type which is almost always the empty string
             # apart from bools and ints where it's zero.
             default_value=self.get_default_value_for_type(column_type),
-            source_tables=tables_used,
+            source_tables=list(tables_used),
         )
 
     def get_aggregate_expression(
@@ -373,7 +373,7 @@ class EMISBackend:
         ELSE {function}({components}) END""",
             type=column_type,
             default_value=default_value,
-            source_tables=tables_used,
+            source_tables=list(tables_used),
             # It's already been checked that date_format is consistent across
             # the source columns, so we just grab the first one and use the
             # date_format from that

--- a/cohortextractor/patients.py
+++ b/cohortextractor/patients.py
@@ -1678,7 +1678,15 @@ def maximum_of(*column_names, **extra_columns):
           "some_column",
           another_colum=patients.with_these_medications(...)
       )
+
+    This function doesn't accept `return_expectations` but instead derives
+    dummy values from the values of its source columns.
     """
+    if "return_expectations" in extra_columns:
+        raise ValueError(
+            "The `maximum_of` function does not accept `return_expecations` and "
+            "instead derives dummy values from the values of its source columns"
+        )
     aggregate_function = "MAX"
     column_names = column_names + tuple(extra_columns.keys())
     return "aggregate_of", locals()
@@ -1702,7 +1710,15 @@ def minimum_of(*column_names, **extra_columns):
           "some_column",
           another_colum=patients.with_these_medications(...)
       )
+
+    This function doesn't accept `return_expectations` but instead derives
+    dummy values from the values of its source columns.
     """
+    if "return_expectations" in extra_columns:
+        raise ValueError(
+            "The `minimum_of` function does not accept `return_expecations` and "
+            "instead derives dummy values from the values of its source columns"
+        )
     aggregate_function = "MIN"
     column_names = column_names + tuple(extra_columns.keys())
     return "aggregate_of", locals()

--- a/cohortextractor/tpp_backend.py
+++ b/cohortextractor/tpp_backend.py
@@ -374,7 +374,7 @@ class TPPBackend:
             # value for the column type which is almost always the empty string
             # apart from bools and ints where it's zero.
             default_value=self.get_default_value_for_type(column_type),
-            source_tables=tables_used,
+            source_tables=list(tables_used),
         )
 
     def get_aggregate_expression(
@@ -422,7 +422,7 @@ class TPPBackend:
             f"ISNULL(({aggregate_expression}), {quote(default_value)})",
             type=column_type,
             default_value=default_value,
-            source_tables=tables_used,
+            source_tables=list(tables_used),
             # It's already been checked that date_format is consistent across
             # the source columns, so we just grab the first one and use the
             # date_format from that


### PR DESCRIPTION
Previously this blew up due to a set/list confusion.

We also document and enforce that these functions don't take a `return_expectations` argument.