### PR TITLE
Fix bug with "group by population"

### DIFF
--- a/cohortextractor/cohortextractor.py
+++ b/cohortextractor/cohortextractor.py
@@ -348,8 +348,8 @@ def _load_dataframe_for_measures(filename, measures):
         group_by_columns.update(measure.group_by)
     # This is a special column which we don't load from the CSV but whose value
     # is always set to 1 for every row
-    numeric_columns.discard("population")
-    group_by_columns.discard("population")
+    numeric_columns.discard(measure.POPULATION_COLUMN)
+    group_by_columns.discard(measure.POPULATION_COLUMN)
     dtype = {col: "category" for col in group_by_columns}
     for col in numeric_columns:
         dtype[col] = "float64"
@@ -363,7 +363,7 @@ def _load_dataframe_for_measures(filename, measures):
         df = pandas.read_stata(filename, columns=list(dtype.keys()))
     else:
         raise RuntimeError(f"Unsupported file format: {filename}")
-    df["population"] = 1
+    df[measure.POPULATION_COLUMN] = 1
     return df
 
 

--- a/cohortextractor/measure.py
+++ b/cohortextractor/measure.py
@@ -4,6 +4,9 @@ SMALL_NUMBER_THRESHOLD = 5
 
 
 class Measure:
+
+    POPULATION_COLUMN = "population"
+
     def __init__(
         self, id, denominator, numerator, group_by=None, small_number_suppression=False
     ):
@@ -57,7 +60,7 @@ class Measure:
         # exception to this is the "population" column (which we already handle
         # as a special case elsewhere). Grouping by the population column just
         # means: sum everthing together as one big group.
-        if self.group_by != ["population"]:
+        if self.group_by != [self.POPULATION_COLUMN]:
             bad_attr = None
             if self.numerator in self.group_by:
                 bad_attr = "numerator"
@@ -94,7 +97,7 @@ class Measure:
     def _group_rows(self, data):
         if not self.group_by:
             return data
-        elif self.group_by == ["population"]:
+        elif self.group_by == [self.POPULATION_COLUMN]:
             # Group by a function which assigns all rows to the same group
             return data.groupby(lambda _: 0).sum()
         else:

--- a/cohortextractor/measure.py
+++ b/cohortextractor/measure.py
@@ -50,6 +50,24 @@ class Measure:
         else:
             self.group_by = group_by
         self.small_number_suppression = small_number_suppression
+        # In general we can't handle the case where a numerator or denominator
+        # column also appears in the group_by. While you can imagine some weird
+        # use cases, this is almost never going to be what you want and it's
+        # not worth the extra complexity in trying to support it. The one
+        # exception to this is the "population" column (which we already handle
+        # as a special case elsewhere). Grouping by the population column just
+        # means: sum everthing together as one big group.
+        if self.group_by != ["population"]:
+            bad_attr = None
+            if self.numerator in self.group_by:
+                bad_attr = "numerator"
+            if self.denominator in self.group_by:
+                bad_attr = "denominator"
+            if bad_attr:
+                raise ValueError(
+                    f"Column '{getattr(self, bad_attr)}' appears in both {bad_attr}"
+                    f" and group_by"
+                )
 
     def calculate(self, data, reporter):
         """

--- a/cohortextractor/measure.py
+++ b/cohortextractor/measure.py
@@ -76,7 +76,11 @@ class Measure:
     def _group_rows(self, data):
         if not self.group_by:
             return data
-        return data.groupby(self.group_by).sum().reset_index()
+        elif self.group_by == ["population"]:
+            # Group by a function which assigns all rows to the same group
+            return data.groupby(lambda _: 0).sum()
+        else:
+            return data.groupby(self.group_by).sum().reset_index()
 
     def _suppress_small_numbers(self, data, reporter):
         if self.small_number_suppression:

--- a/tests/test_smoketest.py
+++ b/tests/test_smoketest.py
@@ -14,12 +14,13 @@ import cohortextractor
 
 @pytest.mark.parametrize("format", ["csv", "csv.gz", "feather", "dta", "dta.gz"])
 def test_smoketest(tmp_path, format):
+    population_size = 100
     _cohortextractor(
         study="test_smoketest",
         args=[
             "generate_cohort",
             "--expectations-population",
-            "100",
+            str(population_size),
             "--index-date-range",
             "2020-01-01 to 2020-04-01 by month",
             "--output-dir",
@@ -36,6 +37,7 @@ def test_smoketest(tmp_path, format):
             tmp_path,
         ],
     )
+
     # liver_disease_by_stp
     with open(tmp_path / "measure_liver_disease_by_stp.csv") as f:
         contents = list(csv.reader(f))
@@ -49,6 +51,7 @@ def test_smoketest(tmp_path, format):
     assert len(contents) == 1 + (2 * 4)  # Header row + 2 STPs * 4 dates
     dates = set(row[4] for row in contents[1:])
     assert dates == {"2020-01-01", "2020-02-01", "2020-03-01", "2020-04-01"}
+
     # liver_disease_by_stp_and_sex
     with open(tmp_path / "measure_liver_disease_by_stp_and_sex.csv") as f:
         contents = list(csv.reader(f))
@@ -63,16 +66,30 @@ def test_smoketest(tmp_path, format):
     assert len(contents) == 1 + (2 * 2 * 4)  # Header row + 2 STPs * 2 sexes * 4 dates
     dates = set(row[5] for row in contents[1:])
     assert dates == {"2020-01-01", "2020-02-01", "2020-03-01", "2020-04-01"}
+
     # liver_disease
     with open(tmp_path / "measure_liver_disease.csv") as f:
         contents = list(csv.reader(f))
-
     assert contents[0] == [
         "has_chronic_liver_disease",
         "population",
         "value",
         "date",
     ]
+
+    # liver_disease_one_group
+    with open(tmp_path / "measure_liver_disease_one_group.csv") as f:
+        contents = list(csv.reader(f))
+    assert contents[0] == [
+        "has_chronic_liver_disease",
+        "population",
+        "value",
+        "date",
+    ]
+    dates = [row[3] for row in contents[1:]]
+    assert dates == ["2020-01-01", "2020-02-01", "2020-03-01", "2020-04-01"]
+    populations = [float(row[1]) for row in contents[1:]]
+    assert populations == [population_size] * 4
 
 
 def test_suppresses_small_numbers(tmp_path):


### PR DESCRIPTION
This fixes a relatively simple, though annoying to track down, bug in the measures framework when using the "population" column as both a numerator (to get per-capita values) and as a group_by column (to treat the entire population as a single group). In this case, the group_by operation overrides the sum, so that the population column ends up with a value of 1, rather than the sum of the population. There was a measure exercising this behaviour in the test fixture, but nothing was asserted about its output.

This PR correctly handles the "population" case, and raises an error for any other cases of overlap between numerator/denominator and group_by columns.