### PR TITLE
chore: Restructure Docker build for better layering

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,19 +21,19 @@ ENV PATH=$PATH:/opt/mssql-tools/bin
 RUN \
   mkdir /app && \
   mkdir /workspace
+COPY ./requirements.txt /app/requirements.txt
+RUN \
+  python -m pip install --upgrade 'pip>=21,<22' && \
+  python -m pip install --requirement /app/requirements.txt
+
+# Install the application
 COPY . /app
-
-# We have to set this because requirements.txt contains relative path
-# references
-WORKDIR /app
-
 # We run `cohortextractor --help` at the end to force dependencies to import
 # because the first time we import matplotlib we get a "generated new
 # fontManager" message and we want to trigger that now rather than every time
 # we run the docker image
 RUN \
-  python -m pip install --upgrade 'pip>=21,<22' && \
-  python -m pip install --requirement requirements.txt && \
+  pip install --editable /app && \
   cohortextractor --help
 
 WORKDIR /workspace

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,10 +5,12 @@
 #    pip-compile
 #
 
-# pip-compile will replace this with the absolute path to this directory, which breaks
-# CI -- don't check that change in!
+# pip-compile will uncomment the below line (and replace the "." with the
+# absolute path to this directory) -- don't check that change in! We're
+# deliberately doing the editable install in a separate command for better
+# Docker layering
 
--e .
+# -e .
     # via -r requirements.in
 
 appdirs==1.4.4


### PR DESCRIPTION
Thanks to PySpark our dependencies are now pretty big. Previously, due
to the structure of our Dockerfile every code change however minor
required all dependencies to be re-installed into a new layer which
makes the update much larger for users to pull down.

This PR seperates out the installation of our dependencies from
the installation of the code which should mean that small code changes
require only small new layers to be pulled.