### PR TITLE
Make driver packages an optional dependency

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -1,22 +1,5 @@
--e .
-
-# This is a pre-built wheel of cTDS, which supports accessing MSSQL databases
-# using the TDS protocol.  We're using this because we had problems downloading
-# large amounts of data over ODBC.  If you're on a platform other than Linux
-# then you'll have to install cTDS yourself:
-# https://zillow.github.io/ctds/install.html
-#
-# For more background on this see:
-# https://github.com/opensafely/cohort-extractor/pull/286
-#
-https://github.com/opensafely/ctds-binary/raw/9466f4bdb8eb70318256115c3bbb6b3ecc9351d0/dist/ctds-1.13.0-cp38-cp38-manylinux2014_x86_64.whl ; sys_platform == "linux"
-
-# We still use pyODBC in our tests because we use SQLAlchemy to set up our test
-# data and there's currently no SQLAlchemy adapter for cTDS. I managed to get
-# one mostly working, but it tripped up on the hyphen separated field names in
-# the EMIS backend. Once these have been removed it might be worth trying
-# again.
-pyodbc
+# Install the extra "driver" dependencies
+-e file:.[drivers]
 
 # development
 black

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,14 +5,12 @@
 #    pip-compile
 #
 
-# pip-compile will uncomment the below line (and replace the "." with the
-# absolute path to this directory) -- don't check that change in! We're
-# deliberately doing the editable install in a separate command for better
-# Docker layering
+# pip-compile will uncomment the below `-e` line -- don't check that change in!
+# We're deliberately doing the editable install in a separate command for
+# better Docker layering
 
-# -e .
+# -e file:.
     # via -r requirements.in
-
 appdirs==1.4.4
     # via
     #   black
@@ -36,8 +34,8 @@ click==7.1.2
     #   presto-python-client
 cryptography==3.3.2
     # via pyopenssl
-https://github.com/opensafely/ctds-binary/raw/9466f4bdb8eb70318256115c3bbb6b3ecc9351d0/dist/ctds-1.13.0-cp38-cp38-manylinux2014_x86_64.whl ; sys_platform == "linux"
-    # via -r requirements.in
+https://github.com/opensafely/ctds-binary/raw/9466f4bdb8eb70318256115c3bbb6b3ecc9351d0/dist/ctds-1.13.0-cp38-cp38-manylinux2014_x86_64.whl#egg=ctds;sys_platform=='linux'
+    # via opensafely-cohort-extractor
 cycler==0.10.0
     # via matplotlib
 decorator==4.4.2
@@ -112,7 +110,7 @@ pycparser==2.20
 pyflakes==2.2.0
     # via flake8
 pyodbc==4.0.30
-    # via -r requirements.in
+    # via opensafely-cohort-extractor
 pyopenssl==20.0.1
     # via requests-pkcs12
 pyparsing==2.4.7

--- a/setup.py
+++ b/setup.py
@@ -17,10 +17,8 @@ setup(
         "lz4",
         "opensafely-jobrunner>=2.0,<3.0",
         "pandas",
-        "presto-python-client",
         "prettytable",
         "pyarrow",
-        "pyspark",
         "pyyaml",
         "requests",
         "requests-pkcs12",
@@ -32,6 +30,26 @@ setup(
         "tabulate",
         "tinynetrc",
     ],
+    extras_require={
+        "drivers": [
+            # Used by the Databricks backend
+            "pyspark",
+            # Used by the EMIS backend
+            "presto-python-client",
+            # Used by the TPP backend
+            # This is a pre-built wheel of cTDS, which supports accessing MSSQL
+            # databases using the TDS protocol.  We're using this because we
+            # had problems downloading large amounts of data over ODBC.  If
+            # you're on a platform other than Linux then you'll have to install
+            # cTDS yourself:
+            # https://zillow.github.io/ctds/install.html
+            #
+            # For more background on this see:
+            # https://github.com/opensafely/cohort-extractor/pull/286
+            "ctds@https://github.com/opensafely/ctds-binary/raw/9466f4bdb8eb70318256115c3bbb6b3ecc9351d0/dist/ctds-1.13.0-cp38-cp38-manylinux2014_x86_64.whl#egg=ctds;sys_platform=='linux'",
+            "pyodbc",
+        ]
+    },
     entry_points={
         "console_scripts": ["cohortextractor=cohortextractor.cohortextractor:main"]
     },


### PR DESCRIPTION
Although most usage of the cohortextractor is via the Docker image we built there are still two contexts in which we want to pip install it:

 1. When building the docs so we can pull the relevant docstrings and function signatures into the docs
 2. Inside the python-docker image so that researchers can import their own study definitions as part of their analysis pipeline.

In neither case do we need to actually talk to a real database and thus we don't need all the heavyweight driver dependencies.

This PR makes those optional dependencies (under the name `drivers`) and restores a test to ensure we don't accidentally import any of these when loading a study definition.