### PR TITLE
fix: Fix packaging

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -1,6 +1,16 @@
 # Install the extra "driver" dependencies
 -e file:.[drivers]
 
+# This is a pre-built wheel of cTDS, which supports accessing MSSQL databases
+# using the TDS protocol.  We're using this because we had problems downloading
+# large amounts of data over ODBC.  If you're on a platform other than Linux
+# then you'll have to install cTDS yourself:
+# https://zillow.github.io/ctds/install.html
+#
+# For more background on this see:
+# https://github.com/opensafely/cohort-extractor/pull/286
+ctds @ https://github.com/opensafely/ctds-binary/raw/9466f4bdb8eb70318256115c3bbb6b3ecc9351d0/dist/ctds-1.13.0-cp38-cp38-manylinux2014_x86_64.whl#egg=ctds;sys_platform=='linux'
+
 # development
 black
 flake8

--- a/requirements.txt
+++ b/requirements.txt
@@ -34,8 +34,10 @@ click==7.1.2
     #   presto-python-client
 cryptography==3.3.2
     # via pyopenssl
-https://github.com/opensafely/ctds-binary/raw/9466f4bdb8eb70318256115c3bbb6b3ecc9351d0/dist/ctds-1.13.0-cp38-cp38-manylinux2014_x86_64.whl#egg=ctds;sys_platform=='linux'
-    # via opensafely-cohort-extractor
+https://github.com/opensafely/ctds-binary/raw/9466f4bdb8eb70318256115c3bbb6b3ecc9351d0/dist/ctds-1.13.0-cp38-cp38-manylinux2014_x86_64.whl#egg=ctds ; sys_platform == "linux"
+    # via
+    #   -r requirements.in
+    #   opensafely-cohort-extractor
 cycler==0.10.0
     # via matplotlib
 decorator==4.4.2

--- a/setup.py
+++ b/setup.py
@@ -37,16 +37,7 @@ setup(
             # Used by the EMIS backend
             "presto-python-client",
             # Used by the TPP backend
-            # This is a pre-built wheel of cTDS, which supports accessing MSSQL
-            # databases using the TDS protocol.  We're using this because we
-            # had problems downloading large amounts of data over ODBC.  If
-            # you're on a platform other than Linux then you'll have to install
-            # cTDS yourself:
-            # https://zillow.github.io/ctds/install.html
-            #
-            # For more background on this see:
-            # https://github.com/opensafely/cohort-extractor/pull/286
-            "ctds@https://github.com/opensafely/ctds-binary/raw/9466f4bdb8eb70318256115c3bbb6b3ecc9351d0/dist/ctds-1.13.0-cp38-cp38-manylinux2014_x86_64.whl#egg=ctds;sys_platform=='linux'",
+            "ctds",
             "pyodbc",
         ]
     },


### PR DESCRIPTION
Including the direct download URL in setup.py caused it to be rejected
by PyPI:

  HTTPError: 400 Bad Request from https://upload.pypi.org/legacy/
  Invalid value for requires_dist. Error: Can't have direct dependency: "ctds @ https:// ...