### PR TITLE
Treat NaN values as being null

### DIFF
--- a/cohortextractor/pandas_utils.py
+++ b/cohortextractor/pandas_utils.py
@@ -1,3 +1,5 @@
+import math
+
 import pandas
 
 
@@ -102,7 +104,7 @@ class Categoriser(dict):
     __call__ = dict.__getitem__
 
     def __missing__(self, value):
-        if value:
+        if is_not_empty(value):
             index = self.counter
             self.counter += 1
         else:
@@ -113,6 +115,17 @@ class Categoriser(dict):
     def get_categories(self):
         enumerated = sorted((index, key) for (key, index) in self.items())
         return [key for (index, key) in enumerated if index > -1]
+
+
+def is_not_empty(value):
+    """
+    We regard falsey and NaN values as empty
+    """
+    if not value:
+        return False
+    if isinstance(value, float) and math.isnan(value):
+        return False
+    return True
 
 
 def memoize(fn):

--- a/tests/test_study_definition.py
+++ b/tests/test_study_definition.py
@@ -44,7 +44,7 @@ def test_create_dummy_data_works_without_database_url(tmp_path, monkeypatch):
 
 @pytest.mark.parametrize("file_format", SUPPORTED_FILE_FORMATS)
 def test_to_file_with_expectations_population(tmp_path, file_format):
-    cl = codelist(["12345"], system="snomed")
+    cl = codelist([("12345", "foo"), ("67890", "bar")], system="snomed")
     study = StudyDefinition(
         default_expectations={"date": {"earliest": "2020-01-01", "latest": "today"}},
         population=patients.all(),
@@ -83,6 +83,15 @@ def test_to_file_with_expectations_population(tmp_path, file_format):
             returning="date",
             date_format="YYYY",
             return_expectations={"rate": "uniform", "incidence": 0.5},
+        ),
+        incomplete_categories=patients.with_these_clinical_events(
+            cl,
+            returning="category",
+            return_expectations={
+                "category": {"ratios": {"foo": 0.5, "bar": 0.5}},
+                # Half the values here should be null
+                "incidence": 0.5,
+            },
         ),
     )
 


### PR DESCRIPTION
In Pandas, all null values should be given a category index of -1.
Previously we used a Python truthiness test which treated NaNs as being
non-null meaning we tried to create a new category with the value `NaN`
which blows up.

Closes #627