### PR TITLE
test: Make the Databricks tests pass inside Docker

### DIFF
--- a/cohortextractor/databricks_backend.py
+++ b/cohortextractor/databricks_backend.py
@@ -132,7 +132,7 @@ class DatabricksBackend:
         # as this connection is from one container to another, not from host
         # to container.
         database_url = os.environ.get(
-            "DATABRICKS_TEST_DATABASE_URL",
+            "DATABRICKS_DATASOURCE_DATABASE_URL",
             "jdbc:sqlserver://localhost:15785;databaseName=Test_OpenCorona",
         )
 

--- a/cohortextractor/databricks_backend.py
+++ b/cohortextractor/databricks_backend.py
@@ -1,3 +1,4 @@
+import os
 from datetime import datetime
 from functools import reduce
 from pathlib import Path
@@ -122,13 +123,23 @@ class DatabricksBackend:
         This currently connects to a SQL Server database.  It is expected that this will
         need to change for production!
         """
+        # The default JDBC URL works for tests when they are run directly on
+        # the host, with the database servers running in Docker Compose.
+        #
+        # If running the cohort-extractor tests *in* Docker Compose, e.g. as
+        # run.sh does, for the connection to succeed, this URL needs to be:
+        # jdbc:sqlserver://mssql:1433;databaseName=Test_OpenCorona
+        # as this connection is from one container to another, not from host
+        # to container.
+        database_url = os.environ.get(
+            "DATABRICKS_TEST_DATABASE_URL",
+            "jdbc:sqlserver://localhost:15785;databaseName=Test_OpenCorona",
+        )
 
         reader = (
             self.session.read.format("jdbc")
             .option("driver", "com.microsoft.sqlserver.jdbc.SQLServerDriver")
-            .option(
-                "url", "jdbc:sqlserver://localhost:15785;databaseName=Test_OpenCorona"
-            )
+            .option("url", database_url)
             .option("user", "SA")
             .option("password", "Your_password123!")
         )

--- a/run.sh
+++ b/run.sh
@@ -24,6 +24,6 @@ exec docker-compose run \
   -e TPP_DATABASE_URL='mssql://SA:Your_password123!@mssql:1433/Test_OpenCorona' \
   -e EMIS_DATABASE_URL=presto://presto:8080/mssql/dbo \
   -e EMIS_DATASOURCE_DATABASE_URL='mssql://SA:Your_password123!@mssql:1433/Test_EMIS' \
-  -e DATABRICKS_DATABASE_URL='jdbc:sqlserver://mssql:1433;databaseName=Test_OpenCorona' \
+  -e DATABRICKS_DATABASE_URL='databricks' \
   app \
   -- "$@"

--- a/run.sh
+++ b/run.sh
@@ -25,5 +25,6 @@ exec docker-compose run \
   -e EMIS_DATABASE_URL=presto://presto:8080/mssql/dbo \
   -e EMIS_DATASOURCE_DATABASE_URL='mssql://SA:Your_password123!@mssql:1433/Test_EMIS' \
   -e DATABRICKS_DATABASE_URL='databricks' \
+  -e DATABRICKS_TEST_DATABASE_URL='jdbc:sqlserver://mssql:1433;databaseName=Test_OpenCorona' \
   app \
   -- "$@"

--- a/run.sh
+++ b/run.sh
@@ -25,6 +25,6 @@ exec docker-compose run \
   -e EMIS_DATABASE_URL=presto://presto:8080/mssql/dbo \
   -e EMIS_DATASOURCE_DATABASE_URL='mssql://SA:Your_password123!@mssql:1433/Test_EMIS' \
   -e DATABRICKS_DATABASE_URL='databricks' \
-  -e DATABRICKS_TEST_DATABASE_URL='jdbc:sqlserver://mssql:1433;databaseName=Test_OpenCorona' \
+  -e DATABRICKS_DATASOURCE_DATABASE_URL='jdbc:sqlserver://mssql:1433;databaseName=Test_OpenCorona' \
   app \
   -- "$@"


### PR DESCRIPTION
Fixes #586.

This PR adds an environment variable `DATABRICKS_DATASOURCE_DATABASE_URL` to optionally replace the previously hardcoded URL to use for the database tests. This solves the problem where the Databricks tests fail when run within `docker-compose`, e.g. via `run.sh`.

This isn't ideal, especially that a workaround for the tests is in the code, but:
* the URL is already hardcoded for the tests, as it is right now;
* the tests are already monkeypatching `DATABRICKS_DATABASE_URL` and this URL actually needs to start with `databricks` for `get_backend_for_database_url()` to not raise an exception;
* this Databricks code is still in development, not used in production and will likely change in future when there is a more definite implementation.

This PR also fixes the `DATABRICKS_DATABASE_URL` to be `databricks`, so there is no `ValueError` raised by `get_backend_for_database_url()` when running the tests with `run.sh`.