### PR TITLE
fix: #636 minimum_of fails expectations generation with **extra_columns

### DIFF
--- a/cohortextractor/study_definition.py
+++ b/cohortextractor/study_definition.py
@@ -351,32 +351,9 @@ class StudyDefinition:
                 method_name = "max"
             else:
                 raise ValueError(f"Unsupported aggregate function '{fn}'")
-            extra_columns = {
-                k: v
-                for (k, v) in self.covariate_definitions.items()
-                if k in list(definition_args["column_names"]) and v[1]["hidden"]
-            }
-            if extra_columns:
-                extra_study = StudyDefinition(
-                    self._original_covariates["population"],
-                    self.default_expectations,
-                    self.index_date,
-                    **extra_columns,
-                )
-                extra_df = extra_study.make_df_from_expectations(population)
-                non_extra_columns = [
-                    c
-                    for c in list(definition_args["column_names"])
-                    if c not in extra_columns.keys()
-                ]
-                dt = df.dtypes[non_extra_columns[0]]
-                extra_df = extra_df.astype(dt)
-                extra_df = pd.concat(
-                    [df[non_extra_columns], extra_df], ignore_index=True
-                )
-                columns = extra_df[list(definition_args["column_names"])]
-            else:
-                columns = df[list(definition_args["column_names"])]
+            columns = self.get_columns_for_aggregation(
+                population, df, list(definition_args["column_names"])
+            )
             aggregate_method = getattr(columns, method_name)
             df[colname] = aggregate_method(axis=1)
 
@@ -388,6 +365,31 @@ class StudyDefinition:
                 df[colname], **definition_args
             )
         return df
+
+    def get_columns_for_aggregation(self, population, df, column_names):
+        extra_columns = {
+            k: v
+            for (k, v) in self.covariate_definitions.items()
+            if k in column_names and v[1]["hidden"]
+        }
+        if extra_columns:
+            extra_study = StudyDefinition(
+                self._original_covariates["population"],
+                self.default_expectations,
+                self.index_date,
+                **extra_columns,
+            )
+            extra_df = extra_study.make_df_from_expectations(population)
+            non_extra_columns = [
+                c for c in column_names if c not in extra_columns.keys()
+            ]
+            dt = df.dtypes[non_extra_columns[0]]
+            extra_df = extra_df.astype(dt)
+            extra_df = pd.concat([df[non_extra_columns], extra_df], ignore_index=True)
+            columns = extra_df[column_names]
+        else:
+            columns = df[column_names]
+        return columns
 
     def validate_category_expectations(
         self,

--- a/cohortextractor/study_definition.py
+++ b/cohortextractor/study_definition.py
@@ -351,7 +351,32 @@ class StudyDefinition:
                 method_name = "max"
             else:
                 raise ValueError(f"Unsupported aggregate function '{fn}'")
-            columns = df[list(definition_args["column_names"])]
+            extra_columns = {
+                k: v
+                for (k, v) in self.covariate_definitions.items()
+                if k in list(definition_args["column_names"]) and v[1]["hidden"]
+            }
+            if extra_columns:
+                extra_study = StudyDefinition(
+                    self._original_covariates["population"],
+                    self.default_expectations,
+                    self.index_date,
+                    **extra_columns,
+                )
+                extra_df = extra_study.make_df_from_expectations(population)
+                non_extra_columns = [
+                    c
+                    for c in list(definition_args["column_names"])
+                    if c not in extra_columns.keys()
+                ]
+                dt = df.dtypes[non_extra_columns[0]]
+                extra_df = extra_df.astype(dt)
+                extra_df = pd.concat(
+                    [df[non_extra_columns], extra_df], ignore_index=True
+                )
+                columns = extra_df[list(definition_args["column_names"])]
+            else:
+                columns = df[list(definition_args["column_names"])]
             aggregate_method = getattr(columns, method_name)
             df[colname] = aggregate_method(axis=1)
 
@@ -428,7 +453,7 @@ class StudyDefinition:
 
 
 def merge(dict1, dict2):
-    """ Return a new dictionary by merging two dictionaries recursively. """
+    """Return a new dictionary by merging two dictionaries recursively."""
 
     result = copy.deepcopy(dict1)
 

--- a/tests/test_expectation_generators.py
+++ b/tests/test_expectation_generators.py
@@ -836,8 +836,24 @@ def test_make_df_from_expectations_with_aggregate_of():
             returning="date",
             date_format="YYYY-MM-DD",
         ),
-        date_min=patients.minimum_of("date_1", "date_2"),
-        date_max=patients.maximum_of("date_1", "date_2"),
+        date_min=patients.minimum_of(
+            "date_1",
+            "date_2",
+            date_3min=patients.with_these_clinical_events(
+                codelist(["X"], system="ctv3"),
+                returning="date",
+                date_format="YYYY-MM-DD",
+            ),
+        ),
+        date_max=patients.maximum_of(
+            "date_1",
+            "date_2",
+            date_3max=patients.with_these_clinical_events(
+                codelist(["X"], system="ctv3"),
+                returning="date",
+                date_format="YYYY-MM-DD",
+            ),
+        ),
     )
     population_size = 10000
     result = study.make_df_from_expectations(population_size)


### PR DESCRIPTION
- add `**extra_columns` column definition to min and max variables in `test_make_df_from_expectations_with_aggregate_of()`
- create columns in for aggregation but not output within `make_df_from_expectations()`:
  - make temporary inner df for extra columns
  - cast columns of temporary df to dtype of first column of `*columns` arg of aggregate column
    - *hacky workaround to fact that date columns in temp df will be converted to string as last step of generation*
  - concat temporary df with `*columns`-based columns
  - pass these concatenated columns to existing aggregation steps