### PR TITLE
fix: Correct wording for `include_month`

### DIFF
--- a/cohortextractor/patients.py
+++ b/cohortextractor/patients.py
@@ -289,7 +289,7 @@ def most_recent_bmi(
             `YYYY-MM` or `YYYY` and wherever possible the least disclosive data should be returned. i.e returning
             only year is less disclosive than a date with day, month and year. Only used if
             include_measurement_date is `True`
-        include_month: a boolean indicating if day should be included in addition to year (deprecated: use
+        include_month: a boolean indicating if month should be included in addition to year (deprecated: use
             `date_format` instead).
         include_day: a boolean indicating if day should be included in addition to year and
             month (deprecated: use `date_format` instead).


### PR DESCRIPTION
Fixes opensafely/documentation#359.