### PR TITLE
fix: #636 support all aggregation scenarios in expecations generation

### DIFF
--- a/cohortextractor/study_definition.py
+++ b/cohortextractor/study_definition.py
@@ -383,9 +383,15 @@ class StudyDefinition:
             non_extra_columns = [
                 c for c in column_names if c not in extra_columns.keys()
             ]
-            dt = df.dtypes[non_extra_columns[0]]
-            extra_df = extra_df.astype(dt)
-            extra_df = pd.concat([df[non_extra_columns], extra_df], ignore_index=True)
+            dt = extra_study.pandas_csv_args["args"][list(extra_columns.keys())[0]][
+                "column_type"
+            ]
+            if dt == "date":
+                extra_df = extra_df.apply(pd.to_datetime)
+            if non_extra_columns:
+                extra_df = pd.concat(
+                    [df[non_extra_columns], extra_df], ignore_index=True
+                )
             columns = extra_df[column_names]
         else:
             columns = df[column_names]


### PR DESCRIPTION
Corrects inadequacies of ecbc922 
- added test scenarios to cover 3 ways in which aggregates can be used
  - using variables defined elsewhere in study
  - using variables only defined within aggregate
  - using a mixture of these
- test integer aggregations as well as date aggregation
- derive data type of columns defined within aggregate using inner study pandas_csv_args
  - convert date columns stringified at end of extra_df generation back to dates
  - datetime-like datatype required for mixed aggregation and stringification at end of method