### PR TITLE
fix: msoa EMIS backend inconsistency

### DIFF
--- a/cohortextractor/emis_backend.py
+++ b/cohortextractor/emis_backend.py
@@ -1121,7 +1121,9 @@ class EMISBackend:
 
         if returning == "stp_code":
             column = "stp_code"
-        elif returning == "msoa_code":
+        # "msoa" is the correct option here, "msoa_code" is supported for
+        # backwards compatibility
+        elif returning in ("msoa", "msoa_code"):
             column = "msoa"
         elif returning == "nuts1_region_name":
             column = "english_region_name"

--- a/tests/test_emis_backend.py
+++ b/tests/test_emis_backend.py
@@ -1209,7 +1209,7 @@ def test_patients_registered_practice_as_of():
     study = StudyDefinition(
         population=patients.all(),
         stp=patients.registered_practice_as_of("2020-02-01", returning="stp_code"),
-        msoa=patients.registered_practice_as_of("2020-02-01", returning="msoa_code"),
+        msoa=patients.registered_practice_as_of("2020-02-01", returning="msoa"),
         region=patients.registered_practice_as_of(
             "2020-02-01", returning="nuts1_region_name"
         ),

--- a/tests/test_emis_backend.py
+++ b/tests/test_emis_backend.py
@@ -1210,6 +1210,9 @@ def test_patients_registered_practice_as_of():
         population=patients.all(),
         stp=patients.registered_practice_as_of("2020-02-01", returning="stp_code"),
         msoa=patients.registered_practice_as_of("2020-02-01", returning="msoa"),
+        deprecated_msoa=patients.registered_practice_as_of(
+            "2020-01-01", returning="msoa_code"
+        ),
         region=patients.registered_practice_as_of(
             "2020-02-01", returning="nuts1_region_name"
         ),
@@ -1220,6 +1223,7 @@ def test_patients_registered_practice_as_of():
     results = study.to_dicts()
     assert [i["stp"] for i in results] == ["789"]
     assert [i["msoa"] for i in results] == ["E0203"]
+    assert [i["deprecated_msoa"] for i in results] == ["E0203"]
     assert [i["region"] for i in results] == ["London"]
     assert [i["pseudo_id"] for i in results] == ["abc"]
 


### PR DESCRIPTION
The [documentation for MSOA](https://docs.opensafely.org/study-def-variables/#cohortextractor.patients.registered_practice_as_of) says that `"msoa"` should be used to specify it. This works in TPP, (which also supports using `"msoa_code"`), but in EMIS only `"msoa_code"` works. This has tripped people up a couple of times.

This PR should make the EMIS backend consistent with TPP: https://github.com/opensafely-core/cohort-extractor/blob/4a339e7fb67a980ee5e9719008afbf25b43c0052/cohortextractor/tpp_backend.py#L1292-L1295