### PR TITLE
feat: implement consultation medium return values for outpatient appointments

### DIFF
--- a/cohortextractor/patients.py
+++ b/cohortextractor/patients.py
@@ -2153,6 +2153,7 @@ def outpatient_appointment_date(
     on_or_after=None,
     between=None,
     date_format="YYYY-MM-DD",
+    find_first_match_in_period=None,
 ):
     """
     Return when the patient had an outpatient appointment
@@ -2163,9 +2164,10 @@ def outpatient_appointment_date(
         returning: string indicating value to be returned. Options are:
 
             * `binary_flag`: indicates if they have had an outpatient appointment or not
-            * `date`: earliest date of outpatient appointment within the specified period
+            * `date`: latest date of outpatient appointment within the specified period
             * `number_of_matches_in_period`: number of outpatient appointments in period
-            * `consultation_medium_used`: consultation medium code for the earliest outpatient appointment within the specified period
+            * `consultation_medium_used`: consultation medium code for the latest outpatient appointment within the specified period
+            * `find_first_match_in_period`: return earliest values for `date` or `consultation_medium_used` (instead of latest)
 
         attended: if True, filters appointments to only those where the patient
             was recorded as being seen. If it is not known whether they attended

--- a/cohortextractor/patients.py
+++ b/cohortextractor/patients.py
@@ -2165,6 +2165,7 @@ def outpatient_appointment_date(
             * `binary_flag`: indicates if they have had an outpatient appointment or not
             * `date`: earliest date of outpatient appointment within the specified period
             * `number_of_matches_in_period`: number of outpatient appointments in period
+            * `consultation_medium_used`: consultation medium code for the earliest outpatient appointment within the specified period
 
         attended: if True, filters appointments to only those where the patient
             was recorded as being seen. If it is not known whether they attended

--- a/cohortextractor/patients.py
+++ b/cohortextractor/patients.py
@@ -2166,7 +2166,7 @@ def outpatient_appointment_date(
             * `binary_flag`: indicates if they have had an outpatient appointment or not
             * `date`: latest date of outpatient appointment within the specified period
             * `number_of_matches_in_period`: number of outpatient appointments in period
-            * `consultation_medium_used`: consultation medium code for the latest outpatient appointment within the specified period
+            * `consultation_medium_used`: consultation medium code for the latest outpatient appointment within the specified period (see https://www.datadictionary.nhs.uk/attributes/consultation_medium_used.html?hl=consultation%2Cmedium )
             * `find_first_match_in_period`: return earliest values for `date` or `consultation_medium_used` (instead of latest)
 
         attended: if True, filters appointments to only those where the patient

--- a/cohortextractor/process_covariate_definitions.py
+++ b/cohortextractor/process_covariate_definitions.py
@@ -344,6 +344,7 @@ class GetColumnType:
             "case_category": "str",
             "category": "str",
             "code": "str",
+            "consultation_medium_used": "str",
             "date": "date",
             "date_admitted": "date",
             "date_arrived": "date",

--- a/cohortextractor/tpp_backend.py
+++ b/cohortextractor/tpp_backend.py
@@ -2449,7 +2449,6 @@ class TPPBackend:
         else:
             raise ValueError(f"Unsupported `returning` value: {returning}")
 
-
         if use_partition_query:
             return f"""
             SELECT

--- a/cohortextractor/tpp_backend.py
+++ b/cohortextractor/tpp_backend.py
@@ -2449,7 +2449,7 @@ class TPPBackend:
         if returning == "binary_flag":
             column_definition = "1"
         elif returning == "date":
-            column_definition = "{date_aggregate}(Appointment_Date)"
+            column_definition = f"""{date_aggregate}(Appointment_Date)"""
         elif returning == "number_of_matches_in_period":
             column_definition = "COUNT(OPA_Ident)"
         elif returning == "consultation_medium_used":

--- a/tests/test_tpp_backend.py
+++ b/tests/test_tpp_backend.py
@@ -3908,7 +3908,7 @@ def test_outpatient_appointment_date_returning_dates():
         population=patients.all(),
         opa=patients.outpatient_appointment_date(returning="date"),
     )
-    assert_results(study.to_dicts(), opa=["2021-01-01", "2021-01-01", "2021-01-02", ""])
+    assert_results(study.to_dicts(), opa=["2021-01-01", "2021-01-02", "2021-01-03", ""])
 
 
 def test_outpatient_appointment_date_returning_dates_first_match():
@@ -3952,7 +3952,9 @@ def test_outpatient_appointment_date_returning_consultation_medium_used():
 
     study = StudyDefinition(
         population=patients.all(),
-        opa=patients.outpatient_appointment_date(returning="consultation_medium_used"),
+        opa=patients.outpatient_appointment_date(
+            returning="consultation_medium_used", find_first_match_in_period=True
+        ),
     )
     assert_results(study.to_dicts(), opa=["10", "20", "40", ""])
 

--- a/tests/test_tpp_backend.py
+++ b/tests/test_tpp_backend.py
@@ -3943,3 +3943,13 @@ def test_outpatient_appointment_date_returning_consultation_medium_used():
         opa=patients.outpatient_appointment_date(returning="consultation_medium_used"),
     )
     assert_results(study.to_dicts(), opa=["10", "20", "40", ""])
+
+
+def test_outpatient_appointment_date_returning_consultation_medium_used_last_match():
+    _make_patient_with_outpatient_appointment()
+
+    study = StudyDefinition(
+        population=patients.all(),
+        opa=patients.outpatient_appointment_date(returning="consultation_medium_used"),
+    )
+    assert_results(study.to_dicts(), opa=["10", "30", "50", ""])

--- a/tests/test_tpp_backend.py
+++ b/tests/test_tpp_backend.py
@@ -3911,6 +3911,18 @@ def test_outpatient_appointment_date_returning_dates():
     assert_results(study.to_dicts(), opa=["2021-01-01", "2021-01-01", "2021-01-02", ""])
 
 
+def test_outpatient_appointment_date_returning_dates_first_match():
+    _make_patient_with_outpatient_appointment()
+
+    study = StudyDefinition(
+        population=patients.all(),
+        opa=patients.outpatient_appointment_date(
+            returning="date", find_first_match_in_period=True
+        ),
+    )
+    assert_results(study.to_dicts(), opa=["2021-01-01", "2021-01-01", "2021-01-02", ""])
+
+
 def test_outpatient_appointment_date_returning_dates_formatted():
     _make_patient_with_outpatient_appointment()
 

--- a/tests/test_tpp_backend.py
+++ b/tests/test_tpp_backend.py
@@ -3768,6 +3768,7 @@ def _make_patient_with_outpatient_appointment():
                         Attendance_Status="6",
                         First_Attendance="1",
                         Treatment_Function_Code="130",
+                        Consultation_Medium_Used="10",
                     ),
                 ]
             ),
@@ -3778,6 +3779,7 @@ def _make_patient_with_outpatient_appointment():
                         Attendance_Status="7",
                         First_Attendance="4",
                         Treatment_Function_Code="180",
+                        Consultation_Medium_Used="20",
                     ),
                     OPA(
                         Appointment_Date="2021-01-02 12:00:00.000",
@@ -3785,6 +3787,7 @@ def _make_patient_with_outpatient_appointment():
                         First_Attendance="2",
                         Treatment_Function_Code="812",
                         OPA_Proc=[OPA_Proc(Primary_Procedure_Code="S603")],
+                        Consultation_Medium_Used="30",
                     ),
                 ]
             ),
@@ -3797,12 +3800,14 @@ def _make_patient_with_outpatient_appointment():
                         First_Attendance="3",
                         Treatment_Function_Code="180",
                         OPA_Proc=[OPA_Proc(Primary_Procedure_Code="D071")],
+                        Consultation_Medium_Used="40",
                     ),
                     OPA(
                         Appointment_Date="2021-01-03 12:00:00.000",
                         Ethnic_Category="GF",
                         First_Attendance="4",
                         Treatment_Function_Code="320",
+                        Consultation_Medium_Used="50",
                     ),
                 ],
             ),
@@ -3928,3 +3933,14 @@ def test_outpatient_appointment_date_returning_number_of_matches_in_period():
         ),
     )
     assert_results(study.to_dicts(), opa=["1", "2", "2", "0"])
+
+def test_outpatient_appointment_date_returning_consultation_medium_used():
+    _make_patient_with_outpatient_appointment()
+
+    study = StudyDefinition(
+        population=patients.all(),
+        opa=patients.outpatient_appointment_date(
+            returning="consultation_medium_used"
+        ),
+    )
+    assert_results(study.to_dicts(), opa=["10", "20", "40", ""])

--- a/tests/test_tpp_backend.py
+++ b/tests/test_tpp_backend.py
@@ -3934,13 +3934,12 @@ def test_outpatient_appointment_date_returning_number_of_matches_in_period():
     )
     assert_results(study.to_dicts(), opa=["1", "2", "2", "0"])
 
+
 def test_outpatient_appointment_date_returning_consultation_medium_used():
     _make_patient_with_outpatient_appointment()
 
     study = StudyDefinition(
         population=patients.all(),
-        opa=patients.outpatient_appointment_date(
-            returning="consultation_medium_used"
-        ),
+        opa=patients.outpatient_appointment_date(returning="consultation_medium_used"),
     )
     assert_results(study.to_dicts(), opa=["10", "20", "40", ""])

--- a/tests/tpp_backend_setup.py
+++ b/tests/tpp_backend_setup.py
@@ -741,6 +741,7 @@ class OPA(Base):
     Ethnic_Category = Column(String)
     First_Attendance = Column(String)
     Treatment_Function_Code = Column(String)
+    Consultation_Medium_Used = Column(String)
 
     OPA_Proc = relationship(
         "OPA_Proc", back_populates="OPA", cascade="all, delete, delete-orphan"


### PR DESCRIPTION
* more functionality from https://github.com/opensafely-core/cohort-extractor/issues/492
* return `consultation_medium_used`
* return either first or last match
* also improve `date` return values to return first or last