### PR TITLE
Sgss matches

### DIFF
--- a/cohortextractor/tpp_backend.py
+++ b/cohortextractor/tpp_backend.py
@@ -1817,7 +1817,7 @@ class TPPBackend:
                             Variant AS variant,
                             VariantDetectionMethod AS variant_detection_method,
                             """
-        empty_variant = """ 
+        empty_variant = """
                 '' AS variant,
                 '' AS variant_detection_method,
                 """
@@ -1913,7 +1913,7 @@ class TPPBackend:
         else:
             positive_query = f"""
             SELECT
-              Patient_ID AS patient_id, 
+              Patient_ID AS patient_id,
               {date_or_count_sql}
               {variant_sql}
               {symptomatic_sql}

--- a/cohortextractor/tpp_backend.py
+++ b/cohortextractor/tpp_backend.py
@@ -1790,6 +1790,17 @@ class TPPBackend:
             )
 
         if (
+            returning == "number_of_matches_in_period"
+            and restrict_to_earliest_specimen_date is not False
+        ):
+            raise ValueError(
+                "Due to limitations in the SGSS data we receive you can only use:\n"
+                "  returning = 'number_of_matches_in_period'\n"
+                "with the options:\n"
+                "  restrict_to_earliest_specimen_date = False\n"
+            )
+
+        if (
             returning in ("variant", "variant_detection_method", "symptomatic")
             and restrict_to_earliest_specimen_date
         ):

--- a/tests/test_tpp_backend.py
+++ b/tests/test_tpp_backend.py
@@ -2360,6 +2360,31 @@ def test_patients_with_test_result_in_sgss():
             restrict_to_earliest_specimen_date=False,
             returning="symptomatic",
         ),
+        number_of_neg_sgss_tests=patients.with_test_result_in_sgss(
+            pathogen="SARS-CoV-2",
+            test_result="negative",
+            restrict_to_earliest_specimen_date=False,
+            returning="number_of_matches_in_period",
+        ),
+        number_of_pos_sgss_tests=patients.with_test_result_in_sgss(
+            pathogen="SARS-CoV-2",
+            test_result="positive",
+            restrict_to_earliest_specimen_date=False,
+            returning="number_of_matches_in_period",
+        ),
+        number_of_all_sgss_tests=patients.with_test_result_in_sgss(
+            pathogen="SARS-CoV-2",
+            test_result="any",
+            restrict_to_earliest_specimen_date=False,
+            returning="number_of_matches_in_period",
+        ),
+        number_of_all_sgss_tests_before_may=patients.with_test_result_in_sgss(
+            pathogen="SARS-CoV-2",
+            test_result="any",
+            on_or_before="2020-05-01",
+            restrict_to_earliest_specimen_date=False,
+            returning="number_of_matches_in_period",
+        ),
     )
     assert_results(
         study.to_dicts(),
@@ -2390,6 +2415,10 @@ def test_patients_with_test_result_in_sgss():
         symptomatic_positive=["Y", "N", "", "", "", ""],
         symptomatic_negative=["N", "N", "", "", "Y", ""],
         symptomatic_any=["N", "N", "", "", "Y", ""],
+        number_of_neg_sgss_tests=["2", "1", "1", "1", "1", "0"],
+        number_of_pos_sgss_tests=["2", "2", "0", "1", "0", "0"],
+        number_of_all_sgss_tests=["4", "3", "1", "2", "1", "0"],
+        number_of_all_sgss_tests_before_may=["0", "2", "1", "2", "1", "0"],
     )
 
 


### PR DESCRIPTION
### Background
Patients can have multiple COVID tests and knowing how many they have had tells us something about their health seeking behaviour and propensity for testing. At present, we can only get information about 1 test at a time. 

See #563 for more Background information.

### What this PR does?
This PR changes the code in `tpp_backend.py` to get a count of all the times that a patient has appeared in one or both tables called `SGSS_AllTests_Negative` and `SGSS_AllTests_Positive`. It then sums these counts together and returns this value. 

It adds a new `returning` option which is `returning="number_of_matches_in_period"` (This is the same API as other parts of study definition that return number of matches such as `with_clinical_events()`). 

The time period can be restricted by using the `on_or_before` or `between` dates as per the existing API. 

See Tests for examples. 

I have added an Error to be raised if `returning="number_of_matches_in_period` with `restrict_to_earliest_specimen_date=True`. 

### What this PR does not do?
It does not yet filter by type of test, such as PCR or Lateral Flow Test. I would like to be done in a separate PR to make it clearer. 
