### PR TITLE
Support returning test counts from SGSS

### DIFF
--- a/cohortextractor/patients.py
+++ b/cohortextractor/patients.py
@@ -1589,6 +1589,15 @@ def with_test_result_in_sgss(
 
     Possible values are "", "Y", "N".
 
+    ### Number of Tests
+
+    The `returning="number_of_matches_in_period"` option (only available in the "All Tests" data)
+    returns a count of the number of tests a patient has had in the defined time period.
+
+    It is used with `test_result` which must be set as "positive", "negative" or "any".
+    `returning="number_of_matches_in_period"` can therefore be used to return the number of
+    positive, negative or all tests.
+
     For more detail on SGSS in general see [PHE_Laboratory_Reporting_Guidelines.pdf][PHE_LRG]
 
     [PHE_LRG]: https://assets.publishing.service.gov.uk/government/uploads/system/uploads/attachment_data/file/739854/PHE_Laboratory_Reporting_Guidelines.pdf
@@ -1624,6 +1633,7 @@ def with_test_result_in_sgss(
             * `variant` (see above)
             * `variant_detection_method` (see above)
             * `symptomatic` (see above)
+            * `number_of_matches_in_period` (see above)
 
         date_format: a string detailing the format of the dates to be returned.
             It can be `YYYY-MM-DD`, `YYYY-MM` or `YYYY` and wherever possible

--- a/cohortextractor/tpp_backend.py
+++ b/cohortextractor/tpp_backend.py
@@ -1790,6 +1790,17 @@ class TPPBackend:
             )
 
         if (
+            returning == "number_of_matches_in_period"
+            and restrict_to_earliest_specimen_date is not False
+        ):
+            raise ValueError(
+                "Due to limitations in the SGSS data we receive you can only use:\n"
+                "  returning = 'number_of_matches_in_period'\n"
+                "with the options:\n"
+                "  restrict_to_earliest_specimen_date = False\n"
+            )
+
+        if (
             returning in ("variant", "variant_detection_method", "symptomatic")
             and restrict_to_earliest_specimen_date
         ):

--- a/cohortextractor/tpp_backend.py
+++ b/cohortextractor/tpp_backend.py
@@ -1811,6 +1811,8 @@ class TPPBackend:
                 f"  restrict_to_earliest_specimen_date = False\n"
             )
 
+        use_partition_query = True
+
         if returning == "binary_flag":
             column = "1"
         elif returning == "date":
@@ -1866,6 +1868,9 @@ class TPPBackend:
                 + [f"WHEN {raw_column} IS NULL THEN {quote('')}"]
             )
             column = f"CASE {case_clauses} ELSE {raw_column} END"
+        elif returning == "number_of_matches_in_period":
+            column = "COUNT(*)"
+            use_partition_query = False
         else:
             raise ValueError(f"Unsupported `returning` value: {returning}")
 
@@ -1918,25 +1923,36 @@ class TPPBackend:
         date_condition, date_joins = self.get_date_condition("t1", "t1.date", between)
         date_ordering = "ASC" if find_first_match_in_period else "DESC"
 
-        return f"""
-        SELECT
-          t2.patient_id AS patient_id,
-          t2.date AS date,
-          {column} AS {returning}
-        FROM (
-          SELECT t1.*,
-            ROW_NUMBER() OVER (
-              PARTITION BY t1.patient_id
-              ORDER BY t1.date {date_ordering}
-            ) AS rownum
-          FROM (
-            {table_query}
-          ) t1
-          {date_joins}
-          WHERE {date_condition}
-        ) t2
-        WHERE t2.rownum = 1
-        """
+        if use_partition_query:
+            return f"""
+            SELECT
+              t2.patient_id AS patient_id,
+              t2.date AS date,
+              {column} AS {returning}
+            FROM (
+              SELECT t1.*,
+                ROW_NUMBER() OVER (
+                  PARTITION BY t1.patient_id
+                  ORDER BY t1.date {date_ordering}
+                ) AS rownum
+              FROM (
+                {table_query}
+              ) t1
+              {date_joins}
+              WHERE {date_condition}
+            ) t2
+            WHERE t2.rownum = 1
+            """
+        else:
+            return f"""
+            SELECT
+              t1.patient_id AS patient_id,
+              {column} AS {returning}
+            FROM ({table_query}) t1
+            {date_joins}
+            WHERE {date_condition}
+            GROUP BY t1.patient_id
+            """
 
     def patients_household_as_of(self, reference_date, returning):
         if reference_date != "2020-02-01":

--- a/tests/test_tpp_backend.py
+++ b/tests/test_tpp_backend.py
@@ -2360,6 +2360,31 @@ def test_patients_with_test_result_in_sgss():
             restrict_to_earliest_specimen_date=False,
             returning="symptomatic",
         ),
+        number_of_neg_sgss_tests=patients.with_test_result_in_sgss(
+            pathogen="SARS-CoV-2",
+            test_result="negative",
+            restrict_to_earliest_specimen_date=False,
+            returning="number_of_matches_in_period",
+        ),
+        number_of_pos_sgss_tests=patients.with_test_result_in_sgss(
+            pathogen="SARS-CoV-2",
+            test_result="positive",
+            restrict_to_earliest_specimen_date=False,
+            returning="number_of_matches_in_period",
+        ),
+        number_of_all_sgss_tests=patients.with_test_result_in_sgss(
+            pathogen="SARS-CoV-2",
+            test_result="any",
+            restrict_to_earliest_specimen_date=False,
+            returning="number_of_matches_in_period",
+        ),
+        number_of_all_sgss_tests_before_may=patients.with_test_result_in_sgss(
+            pathogen="SARS-CoV-2",
+            test_result="any",
+            on_or_before="2020-05-01",
+            restrict_to_earliest_specimen_date=False,
+            returning="number_of_matches_in_period",
+        ),
     )
     assert_results(
         study.to_dicts(),
@@ -2390,6 +2415,10 @@ def test_patients_with_test_result_in_sgss():
         symptomatic_positive=["Y", "N", "", "", "", ""],
         symptomatic_negative=["N", "N", "", "", "Y", ""],
         symptomatic_any=["N", "N", "", "", "Y", ""],
+        number_of_neg_sgss_tests=["2", "1", "1", "1", "1", "0"],
+        number_of_pos_sgss_tests=["2", "2", "0", "1", "0", "0"],
+        number_of_all_sgss_tests=["4", "3", "1", "2", "1", "0"],
+        number_of_all_sgss_tests_before_may=["0", "2", "1", "2", "1", "0"],
     )
 
 


### PR DESCRIPTION
### Background
Patients can have multiple COVID tests and knowing how many they have had tells us something about their health seeking behaviour and propensity for testing. At present, we can only get information about 1 test at a time. 

See #563 for more Background information.

### What this PR does?
This PR changes the code in `tpp_backend.py` to get a count of all the times that a patient has appeared in one or both tables called `SGSS_AllTests_Negative` and `SGSS_AllTests_Positive`. It then sums these counts together and returns this value. 

It adds a new `returning` option which is `returning="number_of_matches_in_period"` (This is the same API as other parts of study definition that return number of matches such as `with_clinical_events()`). 

The time period can be restricted by using the `on_or_before` or `between` dates as per the existing API. 

See Tests for examples. 

I have added an Error to be raised if `returning="number_of_matches_in_period` with `restrict_to_earliest_specimen_date=True`. 

### What this PR does not do?
It does not yet filter by type of test, such as PCR or Lateral Flow Test. I would like to be done in a separate PR to make it clearer. 