### PR TITLE
fix: Fix bug generating dummy data for aggregates

### DIFF
--- a/cohortextractor/study_definition.py
+++ b/cohortextractor/study_definition.py
@@ -374,9 +374,14 @@ class StudyDefinition:
         }
         if extra_columns:
             extra_study = StudyDefinition(
-                self._original_covariates["population"],
-                self.default_expectations,
-                self.index_date,
+                # It doesn't matter what the population is here, it's not
+                # relevant in generating the extra columns we need. But we
+                # can't use the real population definition because that may be
+                # an expression referencing columns which don't appear in our
+                # "extra study" and so will trigger an error.
+                population=("all", {}),
+                default_expectations=self.default_expectations,
+                index_date=self.index_date,
                 **extra_columns,
             )
             extra_df = extra_study.make_df_from_expectations(population)

--- a/tests/test_expectation_generators.py
+++ b/tests/test_expectation_generators.py
@@ -894,7 +894,12 @@ def test_make_df_from_expectations_with_aggregate_of():
             "rate": "exponential_increase",
             "incidence": 1,
         },
-        population=patients.all(),
+        # We use an expression here (never mind that it's a trivial and
+        # pointless one) as that triggers a bug which we want to ensure we've
+        # fixed
+        population=patients.satisfying(
+            "foo OR bar", foo=patients.all(), bar=patients.all()
+        ),
         date_min=patients.maximum_of(
             date_1=patients.with_these_clinical_events(
                 codelist(["X"], system="ctv3"),


### PR DESCRIPTION
As described here:
https://github.com/opensafely/documentation/discussions/406

Specifically, a KeyError was triggered when:
 * `minimum_of`/`maximum_of` was used somewhere in the study with
    internal (or "hidden") columns
 * the `population` definition was an expression referencing other
   columns.

This is due to the somewhat hacky workaround we use for generating dummy
data for these aggregation functions. (No aspersions cast on @Jongmassey
for this: before it worked in _no_ cases, now it works in some cases; so
it's definitely a strict improvement.)

I think the right fix here is to refactor things so that we generate
dummy data for all columns, hidden or visible, in one go and then we
just remove the hidden columns before writing the data out. But the
simpler fix for now is just to hardcode the `population` definition here
to something unproblematic. It plays no actual role in this case, so it
doesn't matter what we set it to.