### PR TITLE
fix: Allow using dates as categories

### DIFF
--- a/cohortextractor/process_covariate_definitions.py
+++ b/cohortextractor/process_covariate_definitions.py
@@ -1,4 +1,6 @@
 import copy
+import datetime
+import re
 
 
 def process_covariate_definitions(covariate_definitions):
@@ -407,7 +409,13 @@ class GetColumnType:
         return self._infer_type_from_categories(category_definitions)
 
     def _infer_type_from_categories(self, category_definitions):
-        categories = list(category_definitions.keys())
+        # Convert date-like strings to dates
+        categories = [
+            datetime.date.fromisoformat(v)
+            if isinstance(v, str) and re.match(r"\d\d\d\d-\d\d-\d\d", v)
+            else v
+            for v in category_definitions.keys()
+        ]
         first_type = type(categories[0])
         for other in categories[1:]:
             if type(other) != first_type:
@@ -424,6 +432,8 @@ class GetColumnType:
             return "float"
         elif first_type is str:
             return "str"
+        elif first_type is datetime.date:
+            return "date"
         else:
             raise ValueError(f"Unhandled category type: {first_type}")
 


### PR DESCRIPTION
This fixes the issue identified here:
https://github.com/opensafely/documentation/discussions/408#discussioncomment-1334495

Previously, it was not possible to use dates as categories because:
 * the system treated them as strings and wouldn't let you use them in
   places where it expected a date; and
 * our "reformat anything that looks like a date" hack would step in and
   reformat these dates in a way that prevented them being used
   elsewhere where ISO strings were expected.

Now they behave as expected so that you can use a column defined with
`categorised_as` as the input to another function which expects a date.

For example:
```py
study = StudyDefinition(
    population=patients.all(),
    eligible_date=patients.categorised_as(
        {
            "2020-04-14": "age >= 80",
            "2020-06-16": "age >= 70 AND age < 80",
            "2020-08-18": "DEFAULT",
        },
        age=patients.age_as_of("2020-01-01"),
    ),
    first_event_after_eligible=patients.with_these_clinical_events(
        codelist(["foo"], system="ctv3"),
        on_or_after="eligible_date",
        find_first_match_in_period=True,
        returning="date",
        date_format="YYYY-MM-DD",
    ),
)
```