### PR TITLE
fix: Revert to using Presto client library

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -31,7 +31,7 @@ click==7.1.2
     # via
     #   black
     #   pip-tools
-    #   trino
+    #   presto-python-client
 cryptography==3.3.2
     # via pyopenssl
 https://github.com/opensafely/ctds-binary/raw/9466f4bdb8eb70318256115c3bbb6b3ecc9351d0/dist/ctds-1.13.0-cp38-cp38-manylinux2014_x86_64.whl#egg=ctds ; sys_platform == "linux"
@@ -91,6 +91,8 @@ pluggy==0.13.1
     # via pytest
 pre-commit==2.9.3
     # via -r requirements.in
+presto-python-client==0.7.0
+    # via opensafely-cohort-extractor
 py==1.10.0
     # via
     #   pytest
@@ -140,8 +142,8 @@ regex==2020.11.13
 requests==2.25.0
     # via
     #   opensafely-cohort-extractor
+    #   presto-python-client
     #   requests-pkcs12
-    #   trino
 requests-pkcs12==1.9
     # via opensafely-cohort-extractor
 retry==0.9.2
@@ -156,9 +158,9 @@ six==1.14.0
     #   cycler
     #   freezegun
     #   packaging
+    #   presto-python-client
     #   pyopenssl
     #   python-dateutil
-    #   trino
     #   virtualenv
 sqlalchemy==1.3.15
     # via opensafely-cohort-extractor
@@ -174,8 +176,6 @@ toml==0.10.2
     # via
     #   black
     #   pre-commit
-trino==0.306.0
-    # via opensafely-cohort-extractor
 typed-ast==1.4.2
     # via black
 typing-extensions==3.7.4.3

--- a/setup.py
+++ b/setup.py
@@ -33,7 +33,7 @@ setup(
             # Used by the Databricks backend
             "pyspark",
             # Used by the EMIS backend
-            "trino",
+            "presto-python-client",
             # Used by the TPP backend
             "ctds",
             "pyodbc",


### PR DESCRIPTION
This reverts the change made in #625 from using
`presto-python-client=0.7.0` to using `trino==0.306.0`. That change
passes tests but triggers 500 errors from the database in production.

Rather than revert the entire PR (which would be a revert of a revert of
a revert) we leave almost all the other changes in place and do some
import munging to access the old client under the new name. This should
buy us some time while we identify the root cause.