### PR TITLE
fix: Allow comparator characters in category names

### DIFF
--- a/cohortextractor/expressions.py
+++ b/cohortextractor/expressions.py
@@ -6,7 +6,10 @@ from sqlparse import tokens as ttypes
 
 IGNORE = object()
 
-SAFE_CHARS_RE = re.compile(r"^[a-zA-Z0-9_]+$")
+# As well as alphanumeric and underscore characters which are generally used
+# for category names, we also have "comparator" categories for which we need to
+# allow the corresponding characters
+SAFE_CHARS_RE = re.compile(r"^[a-zA-Z0-9_<>=~]+$")
 
 
 class InvalidExpressionError(ValueError):
@@ -100,8 +103,8 @@ def validate_string(token):
         raise ValueError(f"String literals must be 16 characters or less: {value}")
     if not SAFE_CHARS_RE.match(value) and not value == "":
         raise ValueError(
-            f"String literals can only contain alphanumeric characters and "
-            f"underscore: {value}"
+            f"String literals can only contain alphanumeric characters, "
+            f"underscore and the comparators '<', '>', '=', and '~': {value}"
         )
     return sqlparse.sql.Token(ttypes.Literal.String.Single, f"'{value}'")
 

--- a/tests/test_expressions.py
+++ b/tests/test_expressions.py
@@ -36,5 +36,7 @@ def test_validate_string():
         format_expression('"no$special$chars"', **kwargs)
     with pytest.raises(ValueError):
         format_expression('"all_ok_characters_but_just_a_bit_too_long"', **kwargs)
+    # We support comparator characters as well as alphanumeric
+    assert format_expression("'<>=~'", **kwargs)[0] == "'<>=~'"
     assert format_expression('"quoted"', **kwargs)[0] == "'quoted'"
     assert format_expression('""', **kwargs)[0] == "''"


### PR DESCRIPTION
Following #655 we now return "comparator" categories which have
non-alphanumeric names. In order to reference these values in
expressions like

     egfr =1  AND  egfr_comparator = '>'

we need to be able to include these values in string literals.