### PR TITLE
feat: add generator for poisson distribution in dummy data

### DIFF
--- a/cohortextractor/expectation_generators.py
+++ b/cohortextractor/expectation_generators.py
@@ -3,7 +3,7 @@ from datetime import datetime
 
 import numpy as np
 import pandas as pd
-from scipy.stats import expon, norm, rv_discrete, uniform
+from scipy.stats import expon, norm, rv_discrete, uniform, poisson
 
 
 def generate_ages(population, max_age=110):
@@ -110,12 +110,15 @@ def generate(population, **kwargs):
             mean = int_["mean"]
             stddev = int_["stddev"]
             df["int"] = norm.rvs(loc=mean, scale=stddev, size=population).astype("int")
+        elif int_["distribution"] == "poisson":
+            mean = int_["mean"]
+            df["int"] = poisson.rvs(mu=mean, size=population)
         elif int_["distribution"] == "population_ages":
             # A distribution that is something like a real UK population
             df["int"] = generate_ages(population)
         else:
             raise ValueError(
-                "Only `normal` and `population_ages` distributions currently supported"
+                "Only `normal`, `poisson`, and `population_ages` distributions currently supported for ints"
             )
     float_ = kwargs.pop("float", None)
     if float_:
@@ -125,7 +128,7 @@ def generate(population, **kwargs):
             df["float"] = norm.rvs(loc=mean, scale=stddev, size=population)
         else:
             raise ValueError(
-                "Only `normal` and `population_ages` distributions currently supported"
+                "Only `normal` distributions currently supported for floats"
             )
 
     bool_ = kwargs.pop("bool", None)

--- a/tests/test_expectation_generators.py
+++ b/tests/test_expectation_generators.py
@@ -293,7 +293,7 @@ def test_data_generator_float():
     assert abs(35 - int(nonzero_results["float"].mean())) < 5
 
 
-def test_data_generator_int():
+def test_data_generator_int_normal():
     population_size = 10000
     incidence = 0.9
     return_expectations = {
@@ -304,6 +304,19 @@ def test_data_generator_int():
     }
     result = generate(population_size, **return_expectations)
     assert abs(10 - int(result["int"].mean())) < 3
+
+
+def test_data_generator_int_poisson():
+    population_size = 10000
+    incidence = 0.9
+    return_expectations = {
+        "rate": "exponential_increase",
+        "incidence": incidence,
+        "date": {"earliest": "1900-01-01", "latest": "2020-01-01"},
+        "int": {"distribution": "poisson", "mean": 5},
+    }
+    result = generate(population_size, **return_expectations)
+    assert abs(5 - int(result["int"].mean())) < 3
 
 
 def test_data_generator_bool():


### PR DESCRIPTION
This was a suggestion from the Bristol users. It gives another option in dummy data variable generation, to provide more realistic variables in some cases.

The advantage of poisson distributions over e.g. a normal distribution is that it fits much better when for example counting events. With a normal distribution, you're likely to end up with negative numbers, which is nonsensical when you're counting events.

I think the code additions themselves are straightforward.