### PR TITLE
fix: Allow string literals of up to 64 characters

### DIFF
--- a/cohortextractor/expressions.py
+++ b/cohortextractor/expressions.py
@@ -99,8 +99,8 @@ def filter_and_validate_tokens(tokens):
 def validate_string(token):
     # Remove quotes
     value = token.value[1:-1]
-    if len(value) > 16:
-        raise ValueError(f"String literals must be 16 characters or less: {value}")
+    if len(value) > 64:
+        raise ValueError(f"String literals must be 64 characters or less: {value}")
     if not SAFE_CHARS_RE.match(value) and not value == "":
         raise ValueError(
             f"String literals can only contain alphanumeric characters, "

--- a/tests/test_expressions.py
+++ b/tests/test_expressions.py
@@ -35,7 +35,7 @@ def test_validate_string():
     with pytest.raises(ValueError):
         format_expression('"no$special$chars"', **kwargs)
     with pytest.raises(ValueError):
-        format_expression('"all_ok_characters_but_just_a_bit_too_long"', **kwargs)
+        format_expression(f'"{"a" * 65}"', **kwargs)  # Too long
     # We support comparator characters as well as alphanumeric
     assert format_expression("'<>=~'", **kwargs)[0] == "'<>=~'"
     assert format_expression('"quoted"', **kwargs)[0] == "'quoted'"


### PR DESCRIPTION
A researcher called `patients.categorised_as` with a logic statement that contained a 24-character string literal. The study raised a `ValueError`. It's reasonable to increase the limit from 16 characters to 64 characters. For more information, see: opensafely/documentation#504.