### PR TITLE
Spaces in string literals

### DIFF
--- a/cohortextractor/expressions.py
+++ b/cohortextractor/expressions.py
@@ -6,10 +6,10 @@ from sqlparse import tokens as ttypes
 
 IGNORE = object()
 
-# As well as alphanumeric and underscore characters which are generally used
-# for category names, we also have "comparator" categories for which we need to
-# allow the corresponding characters
-SAFE_CHARS_RE = re.compile(r"^[a-zA-Z0-9_<>=~]+$")
+# As well as alphanumeric, underscore, and space characters, which are generally used
+# for category names, we also have "comparator" categories for which we need to allow
+# the corresponding characters.
+SAFE_CHARS_RE = re.compile(r"^[a-zA-Z0-9_ <>=~]+$")
 
 
 class InvalidExpressionError(ValueError):

--- a/tests/test_expressions.py
+++ b/tests/test_expressions.py
@@ -31,12 +31,11 @@ def test_validation():
 def test_validate_string():
     kwargs = dict(name_map={}, empty_value_map={})
     with pytest.raises(ValueError):
-        format_expression('"no spaces"', **kwargs)
-    with pytest.raises(ValueError):
         format_expression('"no$special$chars"', **kwargs)
     with pytest.raises(ValueError):
         format_expression(f'"{"a" * 65}"', **kwargs)  # Too long
     # We support comparator characters as well as alphanumeric
+    assert format_expression("'spaces ok'", **kwargs)[0] == "'spaces ok'"
     assert format_expression("'<>=~'", **kwargs)[0] == "'<>=~'"
     assert format_expression('"quoted"', **kwargs)[0] == "'quoted'"
     assert format_expression('""', **kwargs)[0] == "''"

--- a/tests/test_expressions.py
+++ b/tests/test_expressions.py
@@ -34,7 +34,9 @@ def test_validate_string():
         format_expression('"no$special$chars"', **kwargs)
     with pytest.raises(ValueError):
         format_expression(f'"{"a" * 65}"', **kwargs)  # Too long
-    # We support comparator characters as well as alphanumeric
+    # We support comparator characters as well as alphanumeric, underscore, and space
+    # characters.
+    assert format_expression("'underscores_ok'", **kwargs)[0] == "'underscores_ok'"
     assert format_expression("'spaces ok'", **kwargs)[0] == "'spaces ok'"
     assert format_expression("'<>=~'", **kwargs)[0] == "'<>=~'"
     assert format_expression('"quoted"', **kwargs)[0] == "'quoted'"


### PR DESCRIPTION
@elsie-h wanted to use "Yorkshire and The Humber" as a string literal in a logic expression. It is a valid NUTS 1 region name and is returned by `patients.registered_practice_as_of`. However, without allowing spaces in string literals, cohort-extractor raises a `ValueError`. For more information, see opensafely/documentation#504.

I also sneaked an extra assertion into a test 🙂.