### PR TITLE
feat: Support case-control studies with variable index dates

### DIFF
--- a/cohortextractor/patients.py
+++ b/cohortextractor/patients.py
@@ -2424,3 +2424,38 @@ def outpatient_appointment_date(
         return_expectations: as described elsewhere.
     """
     return "outpatient_appointment_date", locals()
+
+
+def with_value_from_file(f_path, returning, type_, date_format="YYYY-MM-DD"):
+    """
+    Returns values from a file.
+
+    Args:
+        f_path: a string indicating the path to the file. The file must be either a csv or a csv.gz file and must contain a `patient_id` column.
+        returning: a string indicating the column to return from the file. Whilst the file may contain several columns, only this column will be returned from the file.
+        type_: a string indicating the type of the column to return from the file. The options are:
+            * `bool`
+            * `date`
+            * `str`
+            * `int`
+            * `float`
+        date_format: a string indicating the format of the date, if `type_="date"`. The options are:
+            * `YYYY-MM-DD` The default value.
+            * `YYYY-MM`
+            * `YYYY`
+
+    This function does not accept a `return_expectations` argument because the file can contain dummy data.
+    """
+    return "with_value_from_file", locals()
+
+
+def which_exist_in_file(f_path):
+    """
+    Returns boolean values indicating whether patients exist in a file.
+
+    Args:
+        f_path: a string indicating the path to the file. The file must be either a csv or a csv.gz file and must contain a `patient_id` column.
+
+    This function does not accept a `return_expectations` argument because the file can contain dummy data.
+    """
+    return "which_exist_in_file", locals()

--- a/cohortextractor/patients.py
+++ b/cohortextractor/patients.py
@@ -2426,20 +2426,20 @@ def outpatient_appointment_date(
     return "outpatient_appointment_date", locals()
 
 
-def with_value_from_file(f_path, returning, type_, date_format="YYYY-MM-DD"):
+def with_value_from_file(f_path, returning, returning_type, date_format="YYYY-MM-DD"):
     """
     Returns values from a file.
 
     Args:
         f_path: a string indicating the path to the file. The file must be either a csv or a csv.gz file and must contain a `patient_id` column.
         returning: a string indicating the column to return from the file. Whilst the file may contain several columns, only this column will be returned from the file.
-        type_: a string indicating the type of the column to return from the file. The options are:
+        returning_type: a string indicating the type of the column to return from the file. The options are:
             * `bool`
             * `date`
             * `str`
             * `int`
             * `float`
-        date_format: a string indicating the format of the date, if `type_="date"`. The options are:
+        date_format: a string indicating the format of the date, if `returning_type="date"`. The options are:
             * `YYYY-MM-DD` The default value.
             * `YYYY-MM`
             * `YYYY`

--- a/cohortextractor/process_covariate_definitions.py
+++ b/cohortextractor/process_covariate_definitions.py
@@ -368,8 +368,8 @@ class GetColumnType:
     def type_of_outpatient_appointment_date(self, returning, **kwargs):
         return self._type_from_return_value(returning)
 
-    def type_of_with_value_from_file(self, type_, **kwargs):
-        return type_
+    def type_of_with_value_from_file(self, returning_type, **kwargs):
+        return returning_type
 
     def type_of_which_exist_in_file(self, **kwargs):
         return "bool"

--- a/cohortextractor/process_covariate_definitions.py
+++ b/cohortextractor/process_covariate_definitions.py
@@ -368,6 +368,12 @@ class GetColumnType:
     def type_of_outpatient_appointment_date(self, returning, **kwargs):
         return self._type_from_return_value(returning)
 
+    def type_of_with_value_from_file(self, type_, **kwargs):
+        return type_
+
+    def type_of_which_exist_in_file(self, **kwargs):
+        return "bool"
+
     def _type_from_return_value(self, returning):
         if returning == "nhse_region_name":
             raise ValueError(

--- a/cohortextractor/tpp_backend.py
+++ b/cohortextractor/tpp_backend.py
@@ -2737,6 +2737,14 @@ class TPPBackend:
             returning = "value"
             returning_type = "bool"
 
+        # Compiled patterns passed to the module-level matching functions are
+        # cached. As we don't use many patterns, we need not worry
+        # about compiling them first.
+        if not re.fullmatch(r"\w+", returning, re.ASCII):
+            raise ValueError(
+                "The column name given by `returning` should contain only alphanumeric characters and the underscore character"
+            )
+
         # Fail before reading the CSV file
         if returning_type == "bool":
             column_type = "INT"

--- a/cohortextractor/tpp_backend.py
+++ b/cohortextractor/tpp_backend.py
@@ -2713,39 +2713,45 @@ class TPPBackend:
               OPA.Patient_ID
             """
 
-    def patients_with_value_from_file(self, f_path, returning=None, type_=None):
+    def patients_with_value_from_file(
+        self, f_path, returning=None, returning_type=None
+    ):
         if not is_csv_filename(f_path):
             raise TypeError(f"Unexpected file type {f_path}")
 
-        if returning is not None and type_ is None:
+        if returning is not None and returning_type is None:
             # StudyDefinition.get_pandas_csv_args() should have raised an error before
             # we reach here.
-            raise TypeError("If `returning` is passed, then `type_` must be passed")
+            raise TypeError(
+                "If `returning` is passed, then `returning_type` must be passed"
+            )
 
-        if returning is None and type_ is not None:
-            raise TypeError("If `type_` is passed, then `returning` must be passed")
+        if returning is None and returning_type is not None:
+            raise TypeError(
+                "If `returning_type` is passed, then `returning` must be passed"
+            )
 
-        if returning is None and type_ is None:
+        if returning is None and returning_type is None:
             # If we set these here, then we don't need to keep track of which is None
             # later.
             returning = "value"
-            type_ = "bool"
+            returning_type = "bool"
 
         # Fail before reading the CSV file
-        if type_ == "bool":
+        if returning_type == "bool":
             column_type = "INT"
-        elif type_ == "date":
+        elif returning_type == "date":
             column_type = "DATE"
-        elif type_ == "str":
+        elif returning_type == "str":
             column_type = "VARCHAR(MAX)"
-        elif type_ == "int":
+        elif returning_type == "int":
             column_type = "INT"
-        elif type_ == "float":
+        elif returning_type == "float":
             column_type = "FLOAT"
         else:
             # StudyDefinition.get_pandas_csv_args() should have raised an error before
             # we reach here.
-            raise TypeError(f"Unexpected type {type_}")
+            raise TypeError(f"Unexpected type {returning_type}")
 
         # Which columns of the CSV file should we read?
         usecols = ["patient_id"]

--- a/cohortextractor/tpp_backend.py
+++ b/cohortextractor/tpp_backend.py
@@ -2771,17 +2771,16 @@ class TPPBackend:
 
         # Generate the SQL
         table_name = self.get_temp_table_name("file")
-        column_name = self._current_column_name
         queries = [
             f"""
-            -- Uploading file for {column_name}
+            -- Uploading file for {returning}
             CREATE TABLE {table_name} (
                 patient_id BIGINT,
-                {column_name} {column_type}
+                {returning} {column_type}
             )
             """,
         ]
-        insert_sql = f"INSERT INTO {table_name} (patient_id, {column_name}) VALUES"
+        insert_sql = f"INSERT INTO {table_name} (patient_id, {returning}) VALUES"
 
         batch_size = 999
         for i in range(0, len(values), batch_size):
@@ -2796,7 +2795,7 @@ class TPPBackend:
             f"""
             SELECT
                 patient_id,
-                {column_name} AS {returning}
+                {returning}
             FROM
                 {table_name}
             """

--- a/tests/test_tpp_backend.py
+++ b/tests/test_tpp_backend.py
@@ -4439,6 +4439,22 @@ def test_with_value_from_file_with_invalid_returning_arg():
         )
 
 
+def test_with_value_from_file_with_value_as_returning_arg(patient_ids, tmp_path):
+    # Test that when the returning argument is "value", cells from the this
+    # column are inserted into the database.
+    f_path = _to_csv(
+        [{"patient_id": patient_ids[0], "value": "North East"}],
+        tmp_path,
+    )
+    study = StudyDefinition(
+        population=patients.all(),
+        case_nuts1_region_name=patients.with_value_from_file(
+            f_path, returning="value", returning_type="str"
+        ),
+    )
+    assert_results(study.to_dicts(), case_nuts1_region_name=["North East", ""])
+
+
 def test_patients_which_exist_in_file(patient_ids, tmp_path):
     f_path = _to_csv([{"patient_id": patient_ids[0]}], tmp_path)
     study = StudyDefinition(population=patients.which_exist_in_file(f_path))

--- a/tests/test_tpp_backend.py
+++ b/tests/test_tpp_backend.py
@@ -4356,10 +4356,6 @@ def test_with_bool_value_from_file(patient_ids, tmp_path):
             f_path, returning="has_asthma", type_="bool"
         ),
     )
-    # FIXME: How to distinguish between zero-as-null and zero-as-zero? If a patient was
-    # not in the file but was in the population, then their value would be zero-as-null.
-    # If a patient was in the file and was in the population, and their value in the
-    # file was zero, then their value would be zero-as-zero.
     assert_results(study.to_dicts(), case_has_asthma=["1", "0"])  # zero-as-null
 
 

--- a/tests/test_tpp_backend.py
+++ b/tests/test_tpp_backend.py
@@ -4429,6 +4429,16 @@ def test_with_value_from_file_with_missing_returning_arg():
         )
 
 
+def test_with_value_from_file_with_invalid_returning_arg():
+    with pytest.raises(ValueError):
+        StudyDefinition(
+            population=patients.all(),
+            case_bmi=patients.with_value_from_file(
+                "records.csv", returning="bmi-value", returning_type="float"
+            ),
+        )
+
+
 def test_patients_which_exist_in_file(patient_ids, tmp_path):
     f_path = _to_csv([{"patient_id": patient_ids[0]}], tmp_path)
     study = StudyDefinition(population=patients.which_exist_in_file(f_path))

--- a/tests/test_tpp_backend.py
+++ b/tests/test_tpp_backend.py
@@ -4353,7 +4353,7 @@ def test_with_bool_value_from_file(patient_ids, tmp_path):
     study = StudyDefinition(
         population=patients.all(),
         case_has_asthma=patients.with_value_from_file(
-            f_path, returning="has_asthma", type_="bool"
+            f_path, returning="has_asthma", returning_type="bool"
         ),
     )
     assert_results(study.to_dicts(), case_has_asthma=["1", "0"])  # zero-as-null
@@ -4367,7 +4367,7 @@ def test_with_date_value_from_file(patient_ids, tmp_path):
     study = StudyDefinition(
         population=patients.all(),
         case_index_date=patients.with_value_from_file(
-            f_path, returning="index_date", type_="date"
+            f_path, returning="index_date", returning_type="date"
         ),
     )
     assert_results(study.to_dicts(), case_index_date=["2021-01-01", ""])
@@ -4381,7 +4381,7 @@ def test_with_str_value_from_file(patient_ids, tmp_path):
     study = StudyDefinition(
         population=patients.all(),
         case_nuts1_region_name=patients.with_value_from_file(
-            f_path, returning="nuts1_region_name", type_="str"
+            f_path, returning="nuts1_region_name", returning_type="str"
         ),
     )
     assert_results(study.to_dicts(), case_nuts1_region_name=["North East", ""])
@@ -4391,7 +4391,9 @@ def test_with_int_value_from_file(patient_ids, tmp_path):
     f_path = _to_csv([{"patient_id": patient_ids[0], "age": 21}], tmp_path)
     study = StudyDefinition(
         population=patients.all(),
-        case_age=patients.with_value_from_file(f_path, returning="age", type_="int"),
+        case_age=patients.with_value_from_file(
+            f_path, returning="age", returning_type="int"
+        ),
     )
     assert_results(study.to_dicts(), case_age=["21", "0"])
 
@@ -4400,7 +4402,9 @@ def test_with_float_value_from_file(patient_ids, tmp_path):
     f_path = _to_csv([{"patient_id": patient_ids[0], "bmi": 18.5}], tmp_path)
     study = StudyDefinition(
         population=patients.all(),
-        case_bmi=patients.with_value_from_file(f_path, returning="bmi", type_="float"),
+        case_bmi=patients.with_value_from_file(
+            f_path, returning="bmi", returning_type="float"
+        ),
     )
     assert_results(study.to_dicts(), case_bmi=["18.5", "0.0"])
 
@@ -4410,7 +4414,7 @@ def test_with_value_from_file_with_unexpected_file_type():
         StudyDefinition(
             population=patients.all(),
             case_bmi=patients.with_value_from_file(
-                "records.feather", returning="bmi", type_="float"
+                "records.feather", returning="bmi", returning_type="float"
             ),
         )
 
@@ -4420,7 +4424,7 @@ def test_with_value_from_file_with_missing_returning_arg():
         StudyDefinition(
             population=patients.all(),
             case_bmi=patients.with_value_from_file(
-                "records.csv", returning=None, type_="float"
+                "records.csv", returning=None, returning_type="float"
             ),
         )
 


### PR DESCRIPTION
The `with_value_from_file` and `which_exist_in_file` functions read files, returning values for use in a study definition. They support case-control studies with variable index dates (#671).

This draft PR adds them to the `patients` module and to the TPP backend. I'd appreciate feedback on all aspects of the implementation, and specifically:

* The testing strategy
* The pros and cons of raising `TypeError`s in `cohortextractor.tpp_backend.patients_with_value_from_file`
* The pros and cons of reading the result of each call into its own temporary table