### PR TITLE
ci: Fix broken Trino version check

### DIFF
--- a/.github/workflows/emis_trino_version_check.yaml
+++ b/.github/workflows/emis_trino_version_check.yaml
@@ -21,7 +21,7 @@ jobs:
           python -m pip install --upgrade pip
           python -m venv venv
           # Save time by only installing the necessary requirements for the single test.
-          venv/bin/pip install --progress-bar=off --requirement <(grep -E "^(requests|pyyaml|pytest)==" requirements.*.txt)
+          venv/bin/pip install --progress-bar=off --requirement <(grep --extended-regexp --no-filename "^(requests|pyyaml|pytest)==" requirements.*.txt)
 
       - name: Run version check test
         run: |


### PR DESCRIPTION
When the separate requirements files were added in #605, this broke
because the possibility of multiple files existing wasn't accounted for.

`grep` helpfully has `--no-filename` by default when only one file is
searched. Now we're searching two requirements files, so that implicit
setting broke.

The full flags to `grep` are now included, because it's not too obvious
that `-h` means `--no-filename`.