### PR TITLE
fix: clamp dates to pandas max

### DIFF
--- a/cohortextractor/pandas_utils.py
+++ b/cohortextractor/pandas_utils.py
@@ -138,4 +138,20 @@ def memoize(fn):
     return cache().__getitem__
 
 
-to_datetime = memoize(pandas.to_datetime)
+# dates that different systems use to represent the max date, but are greater
+# than pandas.Timestamp can represent, so we clamp to pandas.Timestamp.max
+MAX_DATES = [
+    "9999-12-30 00:00:00",  # TPP
+]
+
+
+@memoize
+def to_datetime(datestr):
+    try:
+        return pandas.to_datetime(datestr)
+    except pandas.errors.OutOfBoundsDatetime:
+        if datestr in MAX_DATES:
+            # clamp to pandas max
+            return pandas.Timestamp.max
+        else:
+            raise

--- a/tests/test_pandas_utils.py
+++ b/tests/test_pandas_utils.py
@@ -15,6 +15,7 @@ def test_dataframe_from_rows():
         (3, 65, "M", 0, "STP2", "", "2020-07"),
         (4, 42, "F", 17.8, "", "2020-04-10", "2020-08"),
         (5, 18, "M", 26.2, "STP3", "2020-06-20", ""),
+        (6, 44, "M", 14.2, "STP3", "2020-06-20", "9999-12-30 00:00:00"),
     ]
     covariate_definitions = {
         "population": ("satisfying", {"column_type": "bool"}),
@@ -72,6 +73,15 @@ def test_dataframe_from_rows():
             "stp": "STP3",
             "date_admitted": Timestamp("2020-06-20 00:00:00"),
             "date_died": NaT,
+        },
+        {
+            "patient_id": 6,
+            "age": 44,
+            "sex": "M",
+            "bmi": 14.2,
+            "stp": "STP3",
+            "date_admitted": Timestamp("2020-06-20 00:00:00"),
+            "date_died": Timestamp.max,
         },
     ]
 


### PR DESCRIPTION
TPP uses the date `9999-12-31 00:00:00` to represent a max future date,
but this is too large for `pandas.Timestamp` when we download the
results.

So, we clamp this specific date to `pandas.Timestamp.max`.

I chose to be conservative about what dates we clamp, but in theory we
could clamp anything over `2262-04-11 23:47:16.854775807`. But that
would mean actually parsing the date string, which is what pandas is
supposed to do for us, and python stdlib does not have a generic parser
for. And I wasn't sure about the semantics.
