### PR TITLE
fix: Use patient table for date joins on ONS Deaths in EMIS

### DIFF
--- a/cohortextractor/emis_backend.py
+++ b/cohortextractor/emis_backend.py
@@ -504,6 +504,7 @@ class EMISBackend:
         min_date, max_date = between
         min_date_expr, join_tables1 = self.date_ref_to_sql_expr(min_date)
         max_date_expr, join_tables2 = self.date_ref_to_sql_expr(max_date)
+
         joins = [
             f"LEFT JOIN {join_table}\n"
             f"ON {join_table}.registration_id = {table}.registration_id"
@@ -1400,7 +1401,9 @@ class EMISBackend:
         returning="binary_flag",
     ):
         date_condition, date_joins = self.get_date_condition(
-            "o", "date_parse(CAST(o.reg_stat_dod AS VARCHAR), '%Y%m%d')", between
+            "p",
+            "date_parse(CAST(o.reg_stat_dod AS VARCHAR), '%Y%m%d')",
+            between,
         )
         if codelist is not None:
             assert codelist.system == "icd10"


### PR DESCRIPTION
The ONS_DEATHS table has no registration_id, so it can't be joined directly to other tables.  Joins to allow date filtering need to go via the patient table.

Fixes #681 - data extract failed when trying to run the query for this variable:
https://github.com/opensafely/antipsychotics-prescribing-during-COVID-19/blob/2a9ad31cc2f9c290eb697bba64b92c46881940aa/analysis/study_definition.py#L401-L404

With the error:
```PrestoUserError(type=USER_ERROR, name=COLUMN_NOT_FOUND, message="COLUMN_NOT_FOUND: line 9:64: 'o.registration_id'", query_id=20211119_105545_05666_3fci4)
```

The reason for this error is the use of a date in `patients.died_from_any_cause` which is derived from another query.  In this case:

```
    antipsychotics_date = patients.with_these_medications(
                codelist = combine_codelists(antipsychotics_first_gen_codes, antipsychotics_second_gen_codes, 
antipsychotics_injectable_and_depot_codes, prochlorperazine_codes),
                returning = "date",
                find_last_match_in_period = True,
                between = ["index_date", "last_day_of_month(index_date)"],
                date_format = "YYYY-MM-DD",
                return_expectations = {"incidence": 0.1}
            ),
        died_2weeks_post_antipsychotic = patients.died_from_any_cause(
        between = ["antipsychotics_date", "antipsychotics_date + 14 days"],
        returning = "binary_flag",
        )
```

`between = ["antipsychotics_date", "antipsychotics_date + 14 days"]` results in an attempt to join the EMIS `ONS_TABLE` with the `MEDICATION_TABLE` on `registration_id`.  Unlike (I think) all other EMIS tables, the `ONS_TABLE` has no `registration_id`.  It gets joined to the patients table on nhs_no, so any joins that it uses for dates need to be joined to the patient table rather than directly to the ONS_TABLE.