### PR TITLE
fix: Set expectations for value from/in functions

### DIFF
--- a/tests/fixtures/studies/test_patients_from_file/analysis/study_definition_controls.py
+++ b/tests/fixtures/studies/test_patients_from_file/analysis/study_definition_controls.py
@@ -1,0 +1,32 @@
+from cohortextractor import StudyDefinition, patients
+
+CONTROLS = "output/matched_matches.csv"
+
+study = StudyDefinition(
+    index_date="2021-01-01",
+    default_expectations={
+        "date": {"earliest": "1900-01-01", "latest": "2021-01-01"},
+        "rate": "uniform",
+        "incidence": 1,
+    },
+    # This is how we expect `which_exist_in_file` to be used. However, `population` is
+    # bypassed when generating expectations so we need some other way of testing the
+    # function.
+    population=patients.which_exist_in_file(CONTROLS),
+    case_index_date=patients.with_value_from_file(
+        CONTROLS,
+        returning="case_index_date",
+        returning_type="date",
+    ),
+    # We don't expect `which_exist_in_file` to be used like this, but you never know.
+    # Doing so allows us to test the function.
+    exists_in_file=patients.which_exist_in_file(CONTROLS),
+    # Here, `age` is "some other covariate".
+    age=patients.age_as_of(
+        "index_date",
+        return_expectations={
+            "rate": "universal",
+            "int": {"distribution": "population_ages"},
+        },
+    ),
+)

--- a/tests/fixtures/studies/test_patients_from_file/output/matched_matches.csv
+++ b/tests/fixtures/studies/test_patients_from_file/output/matched_matches.csv
@@ -1,0 +1,2 @@
+patient_id,case_index_date
+1,2021-01-01

--- a/tests/test_smoketest.py
+++ b/tests/test_smoketest.py
@@ -131,6 +131,32 @@ def test_suppresses_small_numbers(tmp_path):
     assert results[0]["value"] == ""
 
 
+def test_patients_from_file(tmp_path):
+    population_size = 100
+    _cohortextractor(
+        study="test_patients_from_file",
+        args=[
+            "generate_cohort",
+            "--expectations-population",
+            str(population_size),
+            "--output-dir",
+            tmp_path,
+            "--study-definition",
+            "study_definition_controls",
+        ],
+    )
+    with open(tmp_path / "input_controls.csv") as f:
+        contents = list(csv.reader(f))
+    # The number of rows in the output file must equal the number of rows in the
+    # user-supplied CSV file
+    assert len(contents) == 2
+    assert contents[0] == ["patient_id", "case_index_date", "exists_in_file", "age"]
+    # The following values come from the user-supplied CSV file
+    assert contents[1][0] == "1"  # integer
+    assert contents[1][1] == "2021-01-01"
+    assert contents[1][2] == "1"  # boolean
+
+
 def _cohortextractor(study, args):
     study_path = os.path.join(os.path.dirname(__file__), "fixtures", "studies", study)
     cohortextractor_path = os.path.dirname(os.path.dirname(cohortextractor.__file__))


### PR DESCRIPTION
`StudyDefinition.make_df_from_expectations` expects each function in the `patients` module to accept a `return_expectations` argument.

https://github.com/opensafely-core/cohort-extractor/blob/077dbd8819eb5c5f2ca9101dad2c5e1350b0e9d2/cohortextractor/study_definition.py#L294

Previously, `patients.with_value_from_file` and `patients.which_exist_in_file` didn't accept these arguments. However, these functions weren't called from a smoke-test, so @iaindillingham didn't notice that these arguments were missing. Here, we add these arguments and add a smoke-test.

I considered rewriting the above as:

```python
return_expectations = definition_args.get("return_expectations") or {}
```

However, I feel it's safer to make `with_value_from_file` and `which_exist_in_file` consistent with the other functions in the `patients` module.

Thanks to @rriefu for raising this issue, following [this test](https://github.com/opensafely/amr-uom-brit/runs/4925616820).

Something to note is that `with_value_from_file` and `which_exist_in_file` shouldn't need return expectations; the contents of the files that are passed _are_ the return expectations. However, unpicking cohort-extractor to make this so seems excessive. I'll revisit in a separate issue, if this starts to trip people up.