### PR TITLE
Summary (mean, min, max) recorded values across a range of dates

### DIFF
--- a/cohortextractor/emis_backend.py
+++ b/cohortextractor/emis_backend.py
@@ -804,6 +804,42 @@ class EMISBackend:
             "AVG",
         )
 
+    def patients_min_recorded_value(
+        self,
+        codelist,
+        # What period is the mean over?
+        on_most_recent_day_of_measurement=None,
+        # Set date limits
+        between=None,
+        # Add additional columns indicating when measurement was taken
+        include_date_of_match=False,
+    ):
+        return self._summarised_recorded_value(
+            codelist,
+            on_most_recent_day_of_measurement,
+            between,
+            include_date_of_match,
+            "MIN",
+        )
+
+    def patients_max_recorded_value(
+        self,
+        codelist,
+        # What period is the mean over?
+        on_most_recent_day_of_measurement=None,
+        # Set date limits
+        between=None,
+        # Add additional columns indicating when measurement was taken
+        include_date_of_match=False,
+    ):
+        return self._summarised_recorded_value(
+            codelist,
+            on_most_recent_day_of_measurement,
+            between,
+            include_date_of_match,
+            "MAX",
+        )
+
     def patients_registered_as_of(self, reference_date):
         """
         All patients registed on the given date

--- a/cohortextractor/emis_backend.py
+++ b/cohortextractor/emis_backend.py
@@ -727,52 +727,82 @@ class EMISBackend:
         -- XXX maybe add a "WHERE NULL..." here
         """
 
+    def _summarised_recorded_value(
+        self,
+        codelist,
+        on_most_recent_day_of_measurement,
+        between,
+        include_date_of_match,
+        summary_function,
+    ):
+        date_condition, date_joins = self.get_date_condition(
+            OBSERVATION_TABLE, "effective_date", between
+        )
+        codelist_sql = codelist_to_sql(codelist)
+
+        if on_most_recent_day_of_measurement:
+            # The subquery finds, for each patient, the most recent day on which
+            # they've had a measurement. The outer query selects, for each patient,
+            # the mean value on that day.
+            # Note, there's a CAST in the JOIN condition but apparently SQL Server can still
+            # use an index for this. See: https://stackoverflow.com/a/25564539
+            return f"""
+            SELECT
+            days.registration_id,
+            days.hashed_organisation,
+            {summary_function}({OBSERVATION_TABLE}."value_pq_1") AS value,
+            days.date_measured AS date
+            FROM (
+                SELECT
+                    {OBSERVATION_TABLE}.registration_id,
+                    {OBSERVATION_TABLE}.hashed_organisation,
+                    CAST(MAX(effective_date) AS date) AS date_measured
+                FROM {OBSERVATION_TABLE}
+                {date_joins}
+                WHERE snomed_concept_id IN ({codelist_sql}) AND {date_condition}
+                GROUP BY {OBSERVATION_TABLE}.registration_id, {OBSERVATION_TABLE}.hashed_organisation
+            ) AS days
+            LEFT JOIN {OBSERVATION_TABLE}
+            ON (
+            {OBSERVATION_TABLE}.registration_id = days.registration_id
+            AND {OBSERVATION_TABLE}.snomed_concept_id IN ({codelist_sql})
+            AND CAST({OBSERVATION_TABLE}.effective_date AS date) = days.date_measured
+            )
+            GROUP BY days.registration_id, days.hashed_organisation, days.date_measured
+            """
+        else:
+            assert (
+                include_date_of_match is False
+            ), "Can only include measurement date if on_most_recent_day_of_measurement is True"
+
+            return f"""
+            SELECT
+                {OBSERVATION_TABLE}.registration_id,
+                {OBSERVATION_TABLE}.hashed_organisation,
+                {summary_function}({OBSERVATION_TABLE}."value_pq_1") AS value
+            FROM {OBSERVATION_TABLE}
+                {date_joins}
+            WHERE snomed_concept_id IN ({codelist_sql}) AND {date_condition}
+            GROUP BY {OBSERVATION_TABLE}.registration_id, {OBSERVATION_TABLE}.hashed_organisation
+            """
+
     def patients_mean_recorded_value(
         self,
         codelist,
-        # What period is the mean over? (Only one supported option for now)
+        # What period is the mean over?
         on_most_recent_day_of_measurement=None,
         # Set date limits
         between=None,
         # Add additional columns indicating when measurement was taken
         include_date_of_match=False,
     ):
-        # We only support this option for now
-        assert on_most_recent_day_of_measurement
-        date_condition, date_joins = self.get_date_condition(
-            OBSERVATION_TABLE, "effective_date", between
+        return self._summarised_recorded_value(
+            codelist,
+            on_most_recent_day_of_measurement,
+            between,
+            include_date_of_match,
+            "AVG",
         )
-        codelist_sql = codelist_to_sql(codelist)
-        # The subquery finds, for each patient, the most recent day on which
-        # they've had a measurement. The outer query selects, for each patient,
-        # the mean value on that day.
-        # Note, there's a CAST in the JOIN condition but apparently SQL Server can still
-        # use an index for this. See: https://stackoverflow.com/a/25564539
-        sql = f"""
-        SELECT
-          days.registration_id,
-          days.hashed_organisation,
-          AVG({OBSERVATION_TABLE}."value_pq_1") AS value,
-          days.date_measured AS date
-        FROM (
-            SELECT
-                {OBSERVATION_TABLE}.registration_id,
-                {OBSERVATION_TABLE}.hashed_organisation,
-                CAST(MAX(effective_date) AS date) AS date_measured
-            FROM {OBSERVATION_TABLE}
-            {date_joins}
-            WHERE snomed_concept_id IN ({codelist_sql}) AND {date_condition}
-            GROUP BY {OBSERVATION_TABLE}.registration_id, {OBSERVATION_TABLE}.hashed_organisation
-        ) AS days
-        LEFT JOIN {OBSERVATION_TABLE}
-        ON (
-          {OBSERVATION_TABLE}.registration_id = days.registration_id
-          AND {OBSERVATION_TABLE}.snomed_concept_id IN ({codelist_sql})
-          AND CAST({OBSERVATION_TABLE}.effective_date AS date) = days.date_measured
-        )
-        GROUP BY days.registration_id, days.hashed_organisation, days.date_measured
-        """
-        return sql
 
     def patients_registered_as_of(self, reference_date):
         """

--- a/cohortextractor/patients.py
+++ b/cohortextractor/patients.py
@@ -366,7 +366,8 @@ def mean_recorded_value(
             Filters results to measurements between the two dates provided (inclusive).
             The two dates must be in chronological order.
         include_measurement_date: a boolean indicating if an extra column, named `<variable_name>_date_measured`,
-            should be included in the output.  Can only be used if include_measurement_date is `True`.
+            should be included in the output.  This option can only be True when `on_most_recent_day_of_measurement`
+            is `True` (i.e. the value returned is the mean of measurements on a single day).
         date_format: a string detailing the format of the dates to be returned. It can be `YYYY-MM-DD`,
             `YYYY-MM` or `YYYY` and wherever possible the least disclosive data should be returned. i.e returning
             only year is less disclosive than a date with day, month and year. Only used if
@@ -384,7 +385,7 @@ def mean_recorded_value(
         This creates a variable `bp_sys` returning a float of the most recent systolic blood pressure from
         the record within the time period. In the event of repeated measurements on the same day, these
         are averaged. Patient who do not have this information
-        available do not return a value.  The date of measurement is returned as `bp_sys_date_measured`:
+        available do not return a value.  The date of measurement is returned as `bp_sys_date_measured`, in YYYY-MM format:
 
             bp_sys=patients.mean_recorded_value(
                 systolic_blood_pressure_codes,
@@ -399,19 +400,23 @@ def mean_recorded_value(
                 },
             )
 
-        This creates a variable returning a float of the mean recorded creatine level
-        creatinine level over a 6 month period:
+        Alternatively, the date of measurement can be defined as a separate variable, using `date_of`:
 
-        creatinine=patients.mean_recorded_value(
-            creatinine_codes,
-            on_most_recent_day_of_measurement=False,
-            between=["2019-09-16", "2020-03-15"],
-            return_expectations={
-                "float": {"distribution": "normal", "mean": 150, "stddev": 200},
-                "date": {"earliest": "2019-09-16", "latest": "2020-03-15"},
-                "incidence": 0.75,
-            },
-        ),
+            date_of_bp_sys=patients.date_of("bp_sys", date_format="YYYY-MM")
+
+        This creates a variable returning a float of the mean recorded creatinine level
+        over a 6 month period:
+
+            creatinine=patients.mean_recorded_value(
+                creatinine_codes,
+                on_most_recent_day_of_measurement=False,
+                between=["2019-09-16", "2020-03-15"],
+                return_expectations={
+                    "float": {"distribution": "normal", "mean": 150, "stddev": 200},
+                    "date": {"earliest": "2019-09-16", "latest": "2020-03-15"},
+                    "incidence": 0.75,
+                },
+            )
     """
 
     return "mean_recorded_value", locals()
@@ -456,7 +461,8 @@ def min_recorded_value(
             Filters results to measurements between the two dates provided (inclusive).
             The two dates must be in chronological order.
         include_measurement_date: a boolean indicating if an extra column, named `<variable_name>_date_measured`,
-            should be included in the output.  Can only be used if include_measurement_date is `True`.
+            should be included in the output.  This option can only be True when `on_most_recent_day_of_measurement`
+            is `True` (i.e. the value returned is the minimum measurement taken on a single day).
         date_format: a string detailing the format of the dates to be returned. It can be `YYYY-MM-DD`,
             `YYYY-MM` or `YYYY` and wherever possible the least disclosive data should be returned. i.e returning
             only year is less disclosive than a date with day, month and year. Only used if
@@ -470,7 +476,7 @@ def min_recorded_value(
         This creates a variable `min_bp_sys` returning a float of the most recent systolic blood pressure from
         the record within the time period. In the event of repeated measurements on the same day, the minimum value
         is returned. Patient who do not have this information
-        available do not return a value.  The date of measurement is returned as `min_bp_sys_date_measured`:
+        available do not return a value.  The date of measurement is returned as `min_bp_sys_date_measured`, in YYYY-MM format:
 
             min_bp_sys=patients.min_recorded_value(
                 systolic_blood_pressure_codes,
@@ -485,19 +491,23 @@ def min_recorded_value(
                 },
             )
 
-        This creates a variable returning a float of the minimum recorded creatine level
-        creatinine level over a 6 month period:
+        Alternatively, the date of measurement can be defined as a separate variable, using `date_of`:
 
-        min_creatinine=patients.min_recorded_value(
-            creatinine_codes,
-            on_most_recent_day_of_measurement=False,
-            between=["2019-09-16", "2020-03-15"],
-            return_expectations={
-                "float": {"distribution": "normal", "mean": 150, "stddev": 200},
-                "date": {"earliest": "2019-09-16", "latest": "2020-03-15"},
-                "incidence": 0.75,
-            },
-        ),
+            date_of_min_bp=patients.date_of("min_bp_sys", date_format="YYYY-MM")
+
+        This creates a variable returning a float of the minimum recorded creatinine level
+        over a 6 month period:
+
+            min_creatinine=patients.min_recorded_value(
+                creatinine_codes,
+                on_most_recent_day_of_measurement=False,
+                between=["2019-09-16", "2020-03-15"],
+                return_expectations={
+                    "float": {"distribution": "normal", "mean": 150, "stddev": 200},
+                    "date": {"earliest": "2019-09-16", "latest": "2020-03-15"},
+                    "incidence": 0.75,
+                },
+            )
     """
 
     return "min_recorded_value", locals()
@@ -542,7 +552,8 @@ def max_recorded_value(
             Filters results to measurements between the two dates provided (inclusive).
             The two dates must be in chronological order.
         include_measurement_date: a boolean indicating if an extra column, named `<variable_name>_date_measured`,
-            should be included in the output.  Can only be used if include_measurement_date is `True`.
+            should be included in the output.  This option can only be True when `on_most_recent_day_of_measurement`
+            is `True` (i.e. the value returned is the minimum measurement taken on a single day).
         date_format: a string detailing the format of the dates to be returned. It can be `YYYY-MM-DD`,
             `YYYY-MM` or `YYYY` and wherever possible the least disclosive data should be returned. i.e returning
             only year is less disclosive than a date with day, month and year. Only used if
@@ -556,7 +567,7 @@ def max_recorded_value(
         This creates a variable `max_bp_sys` returning a float of the most recent systolic blood pressure from
         the record within the time period. In the event of repeated measurements on the same day, the maximum
         value is returned. Patient who do not have this information
-        available do not return a value.  The date of measurement is returned as `bp_sys_date_measured`:
+        available do not return a value.  The date of measurement is returned as `bp_sys_date_measured`, in YYYY-MM format:
 
             max_bp_sys=patients.max_recorded_value(
                 systolic_blood_pressure_codes,
@@ -571,19 +582,23 @@ def max_recorded_value(
                 },
             )
 
-        This creates a variable returning a float of the maximum recorded creatine level
-        creatinine level over a 6 month period:
+        Alternatively, the date of measurement can be defined as a separate variable, using `date_of`:
 
-        creatinine=patients.max_recorded_value(
-            creatinine_codes,
-            on_most_recent_day_of_measurement=False,
-            between=["2019-09-16", "2020-03-15"],
-            return_expectations={
-                "float": {"distribution": "normal", "mean": 150, "stddev": 200},
-                "date": {"earliest": "2019-09-16", "latest": "2020-03-15"},
-                "incidence": 0.75,
-            },
-        ),
+            date_of_max_bp=patients.date_of("max_bp_sys", date_format="YYYY-MM")
+
+        This creates a variable returning a float of the maximum recorded creatinine level
+        over a 6 month period:
+
+            creatinine=patients.max_recorded_value(
+                creatinine_codes,
+                on_most_recent_day_of_measurement=False,
+                between=["2019-09-16", "2020-03-15"],
+                return_expectations={
+                    "float": {"distribution": "normal", "mean": 150, "stddev": 200},
+                    "date": {"earliest": "2019-09-16", "latest": "2020-03-15"},
+                    "incidence": 0.75,
+                },
+            )
     """
 
     return "max_recorded_value", locals()

--- a/cohortextractor/patients.py
+++ b/cohortextractor/patients.py
@@ -417,6 +417,178 @@ def mean_recorded_value(
     return "mean_recorded_value", locals()
 
 
+def min_recorded_value(
+    codelist,
+    on_most_recent_day_of_measurement=None,
+    # Required keyword
+    return_expectations=None,
+    # Set date limits
+    on_or_before=None,
+    on_or_after=None,
+    between=None,
+    # Add additional columns indicating when measurement was taken
+    include_measurement_date=False,
+    date_format=None,
+):
+    """
+    Return patients' minimum recorded value of a numerical value as defined by
+    a codelist within the specified period. Optionally, limit to recordings taken on the
+    most recent day of measurement only.  This is important as it allows
+    us to account for multiple measurements taken on one day.
+
+    The date of the most recent measurement can be included by flagging with date format options.
+
+    Args:
+        codelist: a codelist for requested value
+        on_most_recent_day_of_measurement: boolean flag for requesting measurements be on most recent date
+        return_expectations: a dictionary defining the incidence and distribution of expected value
+            within the population in question. This is a 3-item key-value dictionary of "date" and "float".
+            "date" is dictionary itself and should contain the `earliest` and `latest` dates needed in the
+            dummy data. `float` is a dictionary of `distribution`, `mean`, and `stddev`. These values determine
+            the shape of the dummy data returned, and the float means a float will be returned rather than an
+            integer. `incidence` must have a value and this is what percentage of dummy patients have
+            a value. It needs to be a number between 0 and 1.
+        on_or_before: date of interest as a string with the format `YYYY-MM-DD`. Filters results to measurements
+            on or before the given date.
+        on_or_after: date of interest as a string with the format `YYYY-MM-DD`. Filters results to measurements
+            on or after the given date.
+        between: two dates of interest as a list with each date as a string with the format `YYYY-MM-DD`.
+            Filters results to measurements between the two dates provided (inclusive).
+            The two dates must be in chronological order.
+        include_measurement_date: a boolean indicating if an extra column, named `<variable_name>_date_measured`,
+            should be included in the output.  Can only be used if include_measurement_date is `True`.
+        date_format: a string detailing the format of the dates to be returned. It can be `YYYY-MM-DD`,
+            `YYYY-MM` or `YYYY` and wherever possible the least disclosive data should be returned. i.e returning
+            only year is less disclosive than a date with day, month and year. Only used if
+            include_measurement_date is `True`.
+
+    Returns:
+        float: min of value
+
+    Example:
+
+        This creates a variable `min_bp_sys` returning a float of the most recent systolic blood pressure from
+        the record within the time period. In the event of repeated measurements on the same day, the minimum value
+        is returned. Patient who do not have this information
+        available do not return a value.  The date of measurement is returned as `min_bp_sys_date_measured`:
+
+            min_bp_sys=patients.min_recorded_value(
+                systolic_blood_pressure_codes,
+                on_most_recent_day_of_measurement=True,
+                between=["2017-02-01", "2020-01-31"],
+                include_measurement_date=True,
+                date_format="YYYY-MM",
+                return_expectations={
+                    "float": {"distribution": "normal", "mean": 80, "stddev": 10},
+                    "date": {"earliest": "2019-02-01", "latest": "2020-01-31"},
+                    "incidence": 0.95,
+                },
+            )
+
+        This creates a variable returning a float of the minimum recorded creatine level
+        creatinine level over a 6 month period:
+
+        min_creatinine=patients.min_recorded_value(
+            creatinine_codes,
+            on_most_recent_day_of_measurement=False,
+            between=["2019-09-16", "2020-03-15"],
+            return_expectations={
+                "float": {"distribution": "normal", "mean": 150, "stddev": 200},
+                "date": {"earliest": "2019-09-16", "latest": "2020-03-15"},
+                "incidence": 0.75,
+            },
+        ),
+    """
+
+    return "min_recorded_value", locals()
+
+
+def max_recorded_value(
+    codelist,
+    on_most_recent_day_of_measurement=None,
+    # Required keyword
+    return_expectations=None,
+    # Set date limits
+    on_or_before=None,
+    on_or_after=None,
+    between=None,
+    # Add additional columns indicating when measurement was taken
+    include_measurement_date=False,
+    date_format=None,
+):
+    """
+    Return patients' maximum recorded value of a numerical value as defined by
+    a codelist within the specified period. Optionally, limit to recordings taken on the
+    most recent day of measurement only.  This is important as it allows
+    us to account for multiple measurements taken on one day.
+
+    The date of the most recent measurement can be included by flagging with date format options.
+
+    Args:
+        codelist: a codelist for requested value
+        on_most_recent_day_of_measurement: boolean flag for requesting measurements be on most recent date
+        return_expectations: a dictionary defining the incidence and distribution of expected value
+            within the population in question. This is a 3-item key-value dictionary of "date" and "float".
+            "date" is dictionary itself and should contain the `earliest` and `latest` dates needed in the
+            dummy data. `float` is a dictionary of `distribution`, `mean`, and `stddev`. These values determine
+            the shape of the dummy data returned, and the float means a float will be returned rather than an
+            integer. `incidence` must have a value and this is what percentage of dummy patients have
+            a value. It needs to be a number between 0 and 1.
+        on_or_before: date of interest as a string with the format `YYYY-MM-DD`. Filters results to measurements
+            on or before the given date.
+        on_or_after: date of interest as a string with the format `YYYY-MM-DD`. Filters results to measurements
+            on or after the given date.
+        between: two dates of interest as a list with each date as a string with the format `YYYY-MM-DD`.
+            Filters results to measurements between the two dates provided (inclusive).
+            The two dates must be in chronological order.
+        include_measurement_date: a boolean indicating if an extra column, named `<variable_name>_date_measured`,
+            should be included in the output.  Can only be used if include_measurement_date is `True`.
+        date_format: a string detailing the format of the dates to be returned. It can be `YYYY-MM-DD`,
+            `YYYY-MM` or `YYYY` and wherever possible the least disclosive data should be returned. i.e returning
+            only year is less disclosive than a date with day, month and year. Only used if
+            include_measurement_date is `True`.
+
+    Returns:
+        float: max of value
+
+    Example:
+
+        This creates a variable `max_bp_sys` returning a float of the most recent systolic blood pressure from
+        the record within the time period. In the event of repeated measurements on the same day, the maximum
+        value is returned. Patient who do not have this information
+        available do not return a value.  The date of measurement is returned as `bp_sys_date_measured`:
+
+            max_bp_sys=patients.max_recorded_value(
+                systolic_blood_pressure_codes,
+                on_most_recent_day_of_measurement=True,
+                between=["2017-02-01", "2020-01-31"],
+                include_measurement_date=True,
+                date_format="YYYY-MM",
+                return_expectations={
+                    "float": {"distribution": "normal", "mean": 80, "stddev": 10},
+                    "date": {"earliest": "2019-02-01", "latest": "2020-01-31"},
+                    "incidence": 0.95,
+                },
+            )
+
+        This creates a variable returning a float of the maximum recorded creatine level
+        creatinine level over a 6 month period:
+
+        creatinine=patients.max_recorded_value(
+            creatinine_codes,
+            on_most_recent_day_of_measurement=False,
+            between=["2019-09-16", "2020-03-15"],
+            return_expectations={
+                "float": {"distribution": "normal", "mean": 150, "stddev": 200},
+                "date": {"earliest": "2019-09-16", "latest": "2020-03-15"},
+                "incidence": 0.75,
+            },
+        ),
+    """
+
+    return "max_recorded_value", locals()
+
+
 def with_these_medications(
     codelist,
     # Required keyword

--- a/cohortextractor/patients.py
+++ b/cohortextractor/patients.py
@@ -342,10 +342,11 @@ def mean_recorded_value(
 ):
     """
     Return patients' mean recorded value of a numerical value as defined by
-    a codelist on a particular day within the defined period. This is important as allows
+    a codelist within the specified period. Optionally, limit to recordings taken on the
+    most recent day of measurement only.  This is important as it allows
     us to account for multiple measurements taken on one day.
 
-    The date of the measurement can be included by flagging with date format options.
+    The date of the most recent measurement can be included by flagging with date format options.
 
     Args:
         codelist: a codelist for requested value
@@ -364,12 +365,12 @@ def mean_recorded_value(
         between: two dates of interest as a list with each date as a string with the format `YYYY-MM-DD`.
             Filters results to measurements between the two dates provided (inclusive).
             The two dates must be in chronological order.
-        include_measurement_date: a boolean indicating if an extra column, named `date_of_bmi`,
-            should be included in the output.
+        include_measurement_date: a boolean indicating if an extra column, named `<variable_name>_date_measured`,
+            should be included in the output.  Can only be used if include_measurement_date is `True`.
         date_format: a string detailing the format of the dates to be returned. It can be `YYYY-MM-DD`,
             `YYYY-MM` or `YYYY` and wherever possible the least disclosive data should be returned. i.e returning
             only year is less disclosive than a date with day, month and year. Only used if
-            include_measurement_date is `True`
+            include_measurement_date is `True`.
         include_month: a boolean indicating if day should be included in addition to year (deprecated: use
             `date_format` instead).
         include_day: a boolean indicating if day should be included in addition to year and
@@ -383,7 +384,7 @@ def mean_recorded_value(
         This creates a variable `bp_sys` returning a float of the most recent systolic blood pressure from
         the record within the time period. In the event of repeated measurements on the same day, these
         are averaged. Patient who do not have this information
-        available do not return a value:
+        available do not return a value.  The date of measurement is returned as `bp_sys_date_measured`:
 
             bp_sys=patients.mean_recorded_value(
                 systolic_blood_pressure_codes,
@@ -397,6 +398,20 @@ def mean_recorded_value(
                     "incidence": 0.95,
                 },
             )
+
+        This creates a variable returning a float of the mean recorded creatine level
+        creatinine level over a 6 month period:
+
+        creatinine=patients.mean_recorded_value(
+            creatinine_codes,
+            on_most_recent_day_of_measurement=False,
+            between=["2019-09-16", "2020-03-15"],
+            return_expectations={
+                "float": {"distribution": "normal", "mean": 150, "stddev": 200},
+                "date": {"earliest": "2019-09-16", "latest": "2020-03-15"},
+                "incidence": 0.75,
+            },
+        ),
     """
 
     return "mean_recorded_value", locals()

--- a/cohortextractor/process_covariate_definitions.py
+++ b/cohortextractor/process_covariate_definitions.py
@@ -274,6 +274,12 @@ class GetColumnType:
     def type_of_mean_recorded_value(self, **kwargs):
         return "float"
 
+    def type_of_min_recorded_value(self, **kwargs):
+        return "float"
+
+    def type_of_max_recorded_value(self, **kwargs):
+        return "float"
+
     def type_of_registered_as_of(self, **kwargs):
         return "bool"
 

--- a/cohortextractor/tpp_backend.py
+++ b/cohortextractor/tpp_backend.py
@@ -828,7 +828,7 @@ class TPPBackend:
     def patients_mean_recorded_value(
         self,
         codelist,
-        # What period is the mean over? (Only one supported option for now)
+        # What period is the mean over?
         on_most_recent_day_of_measurement=None,
         # Set date limits
         between=None,

--- a/cohortextractor/tpp_backend.py
+++ b/cohortextractor/tpp_backend.py
@@ -843,6 +843,42 @@ class TPPBackend:
             "AVG",
         )
 
+    def patients_min_recorded_value(
+        self,
+        codelist,
+        # What period is the mean over?
+        on_most_recent_day_of_measurement=None,
+        # Set date limits
+        between=None,
+        # Add additional columns indicating when measurement was taken
+        include_date_of_match=False,
+    ):
+        return self._summarised_recorded_value(
+            codelist,
+            on_most_recent_day_of_measurement,
+            between,
+            include_date_of_match,
+            "MIN",
+        )
+
+    def patients_max_recorded_value(
+        self,
+        codelist,
+        # What period is the mean over?
+        on_most_recent_day_of_measurement=None,
+        # Set date limits
+        between=None,
+        # Add additional columns indicating when measurement was taken
+        include_date_of_match=False,
+    ):
+        return self._summarised_recorded_value(
+            codelist,
+            on_most_recent_day_of_measurement,
+            between,
+            include_date_of_match,
+            "MAX",
+        )
+
     def patients_registered_as_of(self, reference_date):
         """
         All patients registed on the given date

--- a/cohortextractor/tpp_backend.py
+++ b/cohortextractor/tpp_backend.py
@@ -770,6 +770,61 @@ class TPPBackend:
         -- XXX maybe add a "WHERE NULL..." here
         """
 
+    def _summarised_recorded_value(
+        self,
+        codelist,
+        on_most_recent_day_of_measurement,
+        between,
+        include_date_of_match,
+        summary_function,
+    ):
+        coded_event_table, coded_event_column = coded_event_table_column(codelist)
+        date_condition, date_joins = self.get_date_condition(
+            coded_event_table, "ConsultationDate", between
+        )
+        codelist_sql = codelist_to_sql(codelist)
+
+        if on_most_recent_day_of_measurement:
+            # The subquery finds, for each patient, the most recent day on which
+            # they've had a measurement. The outer query selects, for each patient,
+            # the mean value on that day.
+            # Note, there's a CAST in the JOIN condition but apparently SQL Server can still
+            # use an index for this. See: https://stackoverflow.com/a/25564539
+            return f"""
+            SELECT
+            days.Patient_ID AS patient_id,
+            {summary_function}({coded_event_table}.NumericValue) AS value,
+            days.date_measured AS date
+            FROM (
+                SELECT {coded_event_table}.Patient_ID, CAST(MAX(ConsultationDate) AS date) AS date_measured
+                FROM {coded_event_table}
+                {date_joins}
+                WHERE {coded_event_column} IN ({codelist_sql}) AND {date_condition}
+                GROUP BY {coded_event_table}.Patient_ID
+            ) AS days
+            LEFT JOIN {coded_event_table}
+            ON (
+            {coded_event_table}.Patient_ID = days.Patient_ID
+            AND {coded_event_table}.{coded_event_column} IN ({codelist_sql})
+            AND CAST({coded_event_table}.ConsultationDate AS date) = days.date_measured
+            )
+            GROUP BY days.Patient_ID, days.date_measured
+            """
+        else:
+            assert (
+                include_date_of_match is False
+            ), "Can only include measurement date if on_most_recent_day_of_measurement is True"
+
+            return f"""
+            SELECT
+                {coded_event_table}.Patient_ID AS patient_id,
+                {summary_function}({coded_event_table}.NumericValue) AS value
+            FROM {coded_event_table}
+                {date_joins}
+            WHERE {coded_event_column} IN ({codelist_sql}) AND {date_condition}
+            GROUP BY {coded_event_table}.Patient_ID
+            """
+
     def patients_mean_recorded_value(
         self,
         codelist,
@@ -780,38 +835,13 @@ class TPPBackend:
         # Add additional columns indicating when measurement was taken
         include_date_of_match=False,
     ):
-        # We only support this option for now
-        assert on_most_recent_day_of_measurement
-        coded_event_table, coded_event_column = coded_event_table_column(codelist)
-        date_condition, date_joins = self.get_date_condition(
-            coded_event_table, "ConsultationDate", between
+        return self._summarised_recorded_value(
+            codelist,
+            on_most_recent_day_of_measurement,
+            between,
+            include_date_of_match,
+            "AVG",
         )
-        codelist_sql = codelist_to_sql(codelist)
-        # The subquery finds, for each patient, the most recent day on which
-        # they've had a measurement. The outer query selects, for each patient,
-        # the mean value on that day.
-        # Note, there's a CAST in the JOIN condition but apparently SQL Server can still
-        # use an index for this. See: https://stackoverflow.com/a/25564539
-        return f"""
-        SELECT
-          days.Patient_ID AS patient_id,
-          AVG({coded_event_table}.NumericValue) AS value,
-          days.date_measured AS date
-        FROM (
-            SELECT {coded_event_table}.Patient_ID, CAST(MAX(ConsultationDate) AS date) AS date_measured
-            FROM {coded_event_table}
-            {date_joins}
-            WHERE {coded_event_column} IN ({codelist_sql}) AND {date_condition}
-            GROUP BY {coded_event_table}.Patient_ID
-        ) AS days
-        LEFT JOIN {coded_event_table}
-        ON (
-          {coded_event_table}.Patient_ID = days.Patient_ID
-          AND {coded_event_table}.{coded_event_column} IN ({codelist_sql})
-          AND CAST({coded_event_table}.ConsultationDate AS date) = days.date_measured
-        )
-        GROUP BY days.Patient_ID, days.date_measured
-        """
 
     def patients_registered_as_of(self, reference_date):
         """

--- a/tests/test_tpp_backend.py
+++ b/tests/test_tpp_backend.py
@@ -873,11 +873,14 @@ def test_bmi_when_only_some_measurements_of_child():
     assert [x["BMI_date_measured"] for x in results] == ["2010-01-01"]
 
 
-def test_mean_recorded_value():
+def test_mean_recorded_value_on_most_recent_day():
     code = "2469."
     session = make_session()
     patient = Patient()
     values = [
+        # This day is within the period but not the most recent, and should be ignored
+        ("2020-01-01", 110),
+        # This is the most recent day; mean taken from these 3 measurements
         ("2020-02-10", 90),
         ("2020-02-10", 100),
         ("2020-02-10", 98),
@@ -909,6 +912,57 @@ def test_mean_recorded_value():
     results = study.to_dicts()
     results = [(i["bp_systolic"], i["bp_systolic_date_measured"]) for i in results]
     assert results == [("96.0", "2020-02-10"), ("0.0", ""), ("0.0", "")]
+
+
+def test_mean_recorded_value_across_date_range():
+    code = "44J3."
+    session = make_session()
+    patient = Patient()
+    values = [
+        # these 4 are within the period
+        ("2020-01-01", 110),
+        ("2020-02-10", 90),
+        ("2020-02-10", 100),
+        ("2020-02-10", 98),
+        # This day is outside period and should be ignored
+        ("2020-04-01", 110),
+    ]
+    for date, value in values:
+        patient.CodedEvents.append(
+            CodedEvent(CTV3Code=code, NumericValue=value, ConsultationDate=date)
+        )
+    patient_with_old_reading = Patient()
+    patient_with_old_reading.CodedEvents.append(
+        CodedEvent(CTV3Code=code, NumericValue=100, ConsultationDate="2010-01-01")
+    )
+    patient_with_no_reading = Patient()
+    session.add_all([patient, patient_with_old_reading, patient_with_no_reading])
+    session.commit()
+    study = StudyDefinition(
+        population=patients.all(),
+        creatine=patients.mean_recorded_value(
+            codelist([code], system="ctv3"),
+            on_most_recent_day_of_measurement=False,
+            between=["2018-01-01", "2020-03-01"],
+        ),
+    )
+    assert_results(study.to_dicts(), creatine=["99.5", "0.0", "0.0"])
+
+
+def test_mean_recorded_value_across_date_range_include_measurement_date_error():
+    with pytest.raises(
+        AssertionError,
+        match="Can only include measurement date if on_most_recent_day_of_measurement is True",
+    ):
+        StudyDefinition(
+            population=patients.all(),
+            creatine=patients.mean_recorded_value(
+                codelist(["44J3."], system="ctv3"),
+                on_most_recent_day_of_measurement=False,
+                between=["2018-01-01", "2020-03-01"],
+                include_measurement_date=True,
+            ),
+        )
 
 
 def test_patient_random_sample():

--- a/tests/test_tpp_backend.py
+++ b/tests/test_tpp_backend.py
@@ -11,6 +11,11 @@ import pytest
 from cohortextractor import StudyDefinition, codelist, patients
 from cohortextractor.date_expressions import InvalidExpressionError
 from cohortextractor.mssql_utils import mssql_connection_params_from_url
+from cohortextractor.patients import (
+    max_recorded_value,
+    mean_recorded_value,
+    min_recorded_value,
+)
 from cohortextractor.tpp_backend import (
     AppointmentStatus,
     escape_like_query_fragment,
@@ -873,13 +878,22 @@ def test_bmi_when_only_some_measurements_of_child():
     assert [x["BMI_date_measured"] for x in results] == ["2010-01-01"]
 
 
-def test_mean_recorded_value_on_most_recent_day():
+@pytest.mark.parametrize(
+    "summary_function,expected",
+    [
+        (mean_recorded_value, [("96.0", "2020-02-10"), ("0.0", ""), ("0.0", "")]),
+        (min_recorded_value, [("90.0", "2020-02-10"), ("0.0", ""), ("0.0", "")]),
+        (max_recorded_value, [("100.0", "2020-02-10"), ("0.0", ""), ("0.0", "")]),
+    ],
+)
+def test_summary_recorded_values_on_most_recent_day(summary_function, expected):
     code = "2469."
     session = make_session()
     patient = Patient()
     values = [
-        # This day is within the period but not the most recent, and should be ignored
+        # These days are within the period but not the most recent, and should be ignored
         ("2020-01-01", 110),
+        ("2020-01-02", 80),
         # This is the most recent day; mean taken from these 3 measurements
         ("2020-02-10", 90),
         ("2020-02-10", 100),
@@ -900,7 +914,7 @@ def test_mean_recorded_value_on_most_recent_day():
     session.commit()
     study = StudyDefinition(
         population=patients.all(),
-        bp_systolic=patients.mean_recorded_value(
+        bp_systolic=summary_function(
             codelist([code], system="ctv3"),
             on_most_recent_day_of_measurement=True,
             between=["2018-01-01", "2020-03-01"],
@@ -911,16 +925,25 @@ def test_mean_recorded_value_on_most_recent_day():
     )
     results = study.to_dicts()
     results = [(i["bp_systolic"], i["bp_systolic_date_measured"]) for i in results]
-    assert results == [("96.0", "2020-02-10"), ("0.0", ""), ("0.0", "")]
+    assert results == expected
 
 
-def test_mean_recorded_value_across_date_range():
+@pytest.mark.parametrize(
+    "summary_function,expected",
+    [
+        (mean_recorded_value, ["95.6", "0.0", "0.0"]),
+        (min_recorded_value, ["80.0", "0.0", "0.0"]),
+        (max_recorded_value, ["110.0", "0.0", "0.0"]),
+    ],
+)
+def test_summary_recorded_values_across_date_range(summary_function, expected):
     code = "44J3."
     session = make_session()
     patient = Patient()
     values = [
-        # these 4 are within the period
+        # these 5 are within the period
         ("2020-01-01", 110),
+        ("2020-01-02", 80),
         ("2020-02-10", 90),
         ("2020-02-10", 100),
         ("2020-02-10", 98),
@@ -940,13 +963,13 @@ def test_mean_recorded_value_across_date_range():
     session.commit()
     study = StudyDefinition(
         population=patients.all(),
-        creatine=patients.mean_recorded_value(
+        creatine=summary_function(
             codelist([code], system="ctv3"),
             on_most_recent_day_of_measurement=False,
             between=["2018-01-01", "2020-03-01"],
         ),
     )
-    assert_results(study.to_dicts(), creatine=["99.5", "0.0", "0.0"])
+    assert_results(study.to_dicts(), creatine=expected)
 
 
 def test_mean_recorded_value_across_date_range_include_measurement_date_error():


### PR DESCRIPTION
Fixes #724 
See issue for rationale for adding this functionality.

Extends `mean_recorded_value` to optionally cover the entire provided range, not just the most recent day of measurement, and adds the equivalent methods for min_recorded_value` and `max_recorded_value`
