### PR TITLE
fix: Fix population size for dummy data

### DIFF
--- a/tests/fixtures/studies/test_patients_from_file/analysis/study_definition_controls.py
+++ b/tests/fixtures/studies/test_patients_from_file/analysis/study_definition_controls.py
@@ -29,4 +29,16 @@ study = StudyDefinition(
             "int": {"distribution": "population_ages"},
         },
     ),
+    # By including the measurement date, we're following a different code path to `age`.
+    bmi=patients.most_recent_bmi(
+        between=["2020-01-01", "index_date"],
+        minimum_age_at_measurement=18,
+        include_measurement_date=True,
+        date_format="YYYY-MM-DD",
+        return_expectations={
+            "date": {"earliest": "2010-02-01", "latest": "2022-01-27"},
+            "float": {"distribution": "normal", "mean": 28, "stddev": 8},
+            "incidence": 0.8,
+        },
+    ),
 )

--- a/tests/test_smoketest.py
+++ b/tests/test_smoketest.py
@@ -150,7 +150,14 @@ def test_patients_from_file(tmp_path):
     # The number of rows in the output file must equal the number of rows in the
     # user-supplied CSV file
     assert len(contents) == 2
-    assert contents[0] == ["patient_id", "case_index_date", "exists_in_file", "age"]
+    assert contents[0] == [
+        "patient_id",
+        "case_index_date",
+        "exists_in_file",
+        "bmi_date_measured",
+        "age",
+        "bmi",
+    ]
     # The following values come from the user-supplied CSV file
     assert contents[1][0] == "1"  # integer
     assert contents[1][1] == "2021-01-01"


### PR DESCRIPTION
When we generate dummy data, `with_value_from_file` and `which_exist_in_file` in effect modify the population size from the value given within *project.yaml* to the number of rows in the user-supplied CSV file. However, when a variable in a study definition includes a dependant date, then an `ndarry` of length "population size" is assigned to a data frame of length "number of rows", which raises a `ValueError`.

Here, we add add such a variable to a study definition to recreate the error (thanks for reporting it, @rriefu). We then ensure that when these functions are present in a study definition, the population size is set to the number of rows in the user-supplied CSV file.

---

Pandas indexing gotcha:

```python
df_100 = pandas.DataFrame(data=range(100), columns=["col_a"])
df_200 = pandas.DataFrame(data=range(200), columns=["col_b"])
df_100["col_b"] = df_200["col_b"]  # inner-join
len(df_100)  # 100

df_100 = pandas.DataFrame(data=range(100), columns=["col_a"])
df_100["col_b"] = numpy.arange(200)  # Or any function that returns an ndarray
# ValueError: Length of values (200) does not match length of index (100)
```