### PR TITLE
Add Therapeutics dataset (Antibody and antivirals)

### DIFF
--- a/cohortextractor/patients.py
+++ b/cohortextractor/patients.py
@@ -2635,6 +2635,75 @@ def outpatient_appointment_date(
     return "outpatient_appointment_date", locals()
 
 
+def with_covid_therapeutics(
+    with_these_statuses=None,
+    with_these_therapeutics=None,
+    with_these_indications=None,
+    # Set date limits
+    on_or_before=None,
+    on_or_after=None,
+    between=None,
+    # Set return type
+    returning="binary_flag",
+    date_format=None,
+    # Matching rule
+    find_first_match_in_period=None,
+    find_last_match_in_period=None,
+    return_expectations=None,
+):
+    """
+    Returns data from the Therapeutics Dataset (TPP backend only)
+
+    Args:
+        with_these_statuses: a status as a string, or a list of such names.
+        Possible values are "Approved", "Treatment Complete", "Treatment Not Started",
+        "Treatment Stopped"
+        with_these_therapeutics: a drug name as a string, or a list of such names, or
+            a codelist containing such names. Results will be filtered to just
+            rows containing any of the supplied names. Note these are not
+            standardised names, they are just the names however they come to us
+            in the original data.
+        with_these_indications: a Covid indication name as a string, or a list
+           of such names.  Possible values are "hospital_onset", "hospitalised_with",
+           "non_hospitalised"
+        returning: string indicating value to be returned. Options are:
+
+            * `binary_flag`: if the patient received any matching therapeutic intervention
+            * `date`: date intervention started
+            * `therapeutic`: string of comma-separated drug names
+            * `risk_group`: string of comma-separated risk conditions
+            * `region`: Region recorded for the therapeutic intervention; note this may be different
+              to the patient's region
+            * `number_of_matches_in_period`
+
+        on_or_before: as described elsewhere
+        on_or_after: as described elsewhere
+        between: as described elsewhere
+        find_first_match_in_period: as described elsewhere
+        find_last_match_in_period: as described elsewhere
+        date_format: a string detailing the format of the treatment dates to be returned.
+            It can be "YYYY-MM-DD", "YYYY-MM" or "YYYY" and wherever possible the least disclosive data should be
+            returned. i.e returning only year is less disclosive than a date with month and year.
+        return_expectations: as described elsewhere
+
+    Example:
+        The first date on which non-hospitalised patients had any approved theraputic
+        after 01 Jan 2022:
+
+            covid_therapeutics=patients.with_covid_therapeutics(
+                therapeutic_matches=therapeutic_codelist,
+                indication_matches="non-hospitalised",
+                approved=True,
+                on_or_after="2022-01-01",
+                find_first_match_in_period=True,
+                returning="date",
+                date_format="YYYY-MM-DD",
+                return_expectations={"date": {"earliest": "2022-01-01"}},
+            )
+    """
+    return "with_covid_therapeutics", locals()
+
+
 def with_value_from_file(f_path, returning, returning_type, date_format="YYYY-MM-DD"):
     """
     Returns values from a file.

--- a/cohortextractor/process_covariate_definitions.py
+++ b/cohortextractor/process_covariate_definitions.py
@@ -380,6 +380,9 @@ class GetColumnType:
     def type_of_which_exist_in_file(self, **kwargs):
         return "bool"
 
+    def type_of_with_covid_therapeutics(self, returning, **kwargs):
+        return self._type_from_return_value(returning)
+
     def _type_from_return_value(self, returning):
         if returning == "nhse_region_name":
             raise ValueError(
@@ -425,11 +428,14 @@ class GetColumnType:
             "place_of_death": "str",
             "primary_diagnosis": "str",
             "pseudo_id": "int",
+            "region": "str",
+            "risk_group": "str",
             "rural_urban_classification": "int",
             "s_gene_target_failure": "str",
             "source_of_admission": "str",
             "stp_code": "str",
             "symptomatic": "str",
+            "therapeutic": "str",
             "underlying_cause_of_death": "str",
             "upper_bound": "float",
             "variant": "str",

--- a/cohortextractor/tpp_backend.py
+++ b/cohortextractor/tpp_backend.py
@@ -2927,12 +2927,16 @@ class TPPBackend:
             raise ValueError(f"Unsupported `returning` value: {returning}")
 
         if use_partition_query:
-            # There can be duplicates per patient in the Therapeutics dataset
-            # These are likely to be invalid in some way, but we keep them in so users
-            # can identify them and deal with them as appropriate
-            # (We remove fully duplicate rows in the temp table only)
-            # Duplicate rows are sorted by all the fields that have been identified to
-            # contain duplicate values for a patient, to ensure a consistent return value
+            # There can be duplicates per patient in the Therapeutics dataset, which differ on one
+            # or more field (We remove fully duplicate rows in the temp table only)
+            # These are likely to be invalid in some way, e.g. the result of entering the form twice
+            # We keep these data in - users can identify whether there are duplicates by using the
+            # `number_of_matches_in_period` return value and deal with them as appropriate
+
+            # We always return just one row per patient, either the first or last by TreatmentStartDate.
+            # The query sorts per-patient rows by all the fields that have been identified to
+            # contain duplicate values for a patient.  In the case of duplicate TreatmentStartDates, this
+            # ensures a consistent return value each time.
             sql = f"""
             SELECT
               t.Patient_ID AS patient_id,

--- a/cohortextractor/tpp_backend.py
+++ b/cohortextractor/tpp_backend.py
@@ -2789,13 +2789,21 @@ class TPPBackend:
             """
 
     def create_therapeutics_table(self):
+        """
+        Create a temporarary Therapeutics table to use for `with_covid_therapeutics` queries
+        All columns in the Therapeutics table are VARCHAR.  This casts the two date columns that
+        we use in queries to DATE type, and adds case insensitive collation to the Interventaion
+        and CurrentStatus columns.
+        All columns are included, including those that we don't use, so that when we remove
+        duplicates, we only remove complete duplicate rows
+        """
         if self._therapeutics_table_name is None:
             self._therapeutics_table_name = self.get_temp_table_name("therapeutics")
             collation = "Latin1_General_CI_AS"
             queries = [
                 f"""
             -- Creating theraputics temp table
-            SELECT
+            SELECT DISTINCT
                 Patient_ID,
                 CAST(TreatmentStartDate AS DATE) AS TreatmentStartDate,
                 CAST(Received AS DATE) AS Received,
@@ -2805,7 +2813,13 @@ class TPPBackend:
                 Region,
                 MOL1_high_risk_cohort,
                 SOT02_risk_cohorts,
-                CASIM05_risk_cohort
+                CASIM05_risk_cohort,
+                AgeAtReceivedDate,
+                FormName,
+                MOL1_onset_of_symptoms,
+                SOT02_onset_of_symptoms,
+                Count,
+                Der_LoadDate
              INTO {self._therapeutics_table_name} FROM Therapeutics
             """
             ]

--- a/tests/test_tpp_backend.py
+++ b/tests/test_tpp_backend.py
@@ -4820,6 +4820,18 @@ def test_with_covid_therapeutics():
                         CASIM05_risk_cohort="IMID and Patients with a tumour",
                         Region="South West",
                     ),
+                    # fully duplicate row is removed and doesn't count when returning number of matches
+                    Therapeutics(
+                        Intervention="Remdesivir",
+                        COVID_indication="non_hospitalised",
+                        CurrentStatus="Approved",
+                        TreatmentStartDate="2021-12-09 00:00:00.000",
+                        Received="2021-12-09 00:00:00.000",
+                        MOL1_high_risk_cohort="Patients with a cancer",
+                        SOT02_risk_cohorts="solid cancer",
+                        CASIM05_risk_cohort="IMID and Patients with a tumour",
+                        Region="South West",
+                    ),
                 ]
             ),
         ],

--- a/tests/test_tpp_backend.py
+++ b/tests/test_tpp_backend.py
@@ -4769,7 +4769,7 @@ def test_coded_events_reference_ranges():
     )
 
 
-def test_therapeutics():
+def test_with_covid_therapeutics():
     session = make_session()
     session.add_all(
         [
@@ -4947,7 +4947,7 @@ def test_therapeutics():
     )
 
 
-def test_therapeutics_dates():
+def test_with_covid_therapeutics_date_filters():
     session = make_session()
     session.add_all(
         [
@@ -4999,3 +4999,20 @@ def test_therapeutics_dates():
     assert_results(
         study.to_dicts(), therapeutic=["B", "C", ""], therapeutic_counts=["1", "1", "1"]
     )
+
+
+def test_with_covid_therapeutics_invalid_indiction():
+
+    with pytest.raises(
+        AssertionError,
+        match="'foo' is not a valid indication; options are hospital_onset, hospitalised_with, non_hospitalised",
+    ):
+        StudyDefinition(
+            population=patients.all(),
+            # returning values: date, therapeutic, risk group, region
+            therapeutic=patients.with_covid_therapeutics(
+                find_first_match_in_period=True,
+                returning="date",
+                with_these_indications=["foo"],
+            ),
+        )

--- a/tests/tpp_backend_setup.py
+++ b/tests/tpp_backend_setup.py
@@ -290,6 +290,11 @@ class Patient(Base):
         back_populates="Patient",
         cascade="all, delete, delete-orphan",
     )
+    Therapeutics = relationship(
+        "Therapeutics",
+        back_populates="Patient",
+        cascade="all, delete, delete-orphan",
+    )
 
 
 class RegistrationHistory(Base):
@@ -915,3 +920,43 @@ class ClusterRandomisedTrialReference(Base):
     TrialName = Column(String)
     TrialDescription = Column(String)
     CPMSNumber = Column(Integer)
+
+
+class Therapeutics(Base):
+    __tablename__ = "Therapeutics"
+
+    # This column isn't in the actual database but SQLAlchemy gets a bit upset
+    # if we don't give it a primary key
+    id = Column(Integer, primary_key=True)
+    Patient_ID = Column(Integer, ForeignKey("Patient.Patient_ID"))
+    Patient = relationship(
+        "Patient", back_populates="Therapeutics", cascade="all, delete"
+    )
+
+    # 'Casirivimab and imdevimab '[note trailing space], 'Molnupiravir', 'Remdesivir', 'sarilumab', 'Sotrovimab' , 'Tocilizumab'
+    Intervention = Column(String)
+
+    # 'hospital_onset', 'hospitalised_with', 'non_hospitalised'
+    COVID_indication = Column(String)
+
+    # 'Approved','Treatment Complete','Treatment Not Started','Treatment Stopped'
+    CurrentStatus = Column(String)
+    TreatmentStartDate = Column(String)
+    Received = Column(String)
+
+    # e.g. 'solid cancer', 'IMID',
+    # look consistent but can be a combination of 2 or more separated with ' and ' e.g. 'renal disease and IMID'
+    # sometimes also contains string "Patients with[ a]"
+    MOL1_high_risk_cohort = Column(String)
+    SOT02_risk_cohorts = Column(String)
+    CASIM05_risk_cohort = Column(String)
+
+    Region = Column(String)
+
+    # Other columns in the table which we don't use:
+    #   AgeAtReceivedDate
+    #   FormName
+    #   MOL1_onset_of_symptoms
+    #   SOT02_onset_of_symptoms
+    #   Count
+    #   Der_LoadDate

--- a/tests/tpp_backend_setup.py
+++ b/tests/tpp_backend_setup.py
@@ -953,10 +953,11 @@ class Therapeutics(Base):
 
     Region = Column(String)
 
-    # Other columns in the table which we don't use:
-    #   AgeAtReceivedDate
-    #   FormName
-    #   MOL1_onset_of_symptoms
-    #   SOT02_onset_of_symptoms
-    #   Count
-    #   Der_LoadDate
+    # Other columns in the table which we add into the temp table (for removing duplicates) but
+    # don't use in queries:
+    AgeAtReceivedDate = Column(String)
+    FormName = Column(String)
+    MOL1_onset_of_symptoms = Column(String)
+    SOT02_onset_of_symptoms = Column(String)
+    Count = Column(String)
+    Der_LoadDate = Column(String)


### PR DESCRIPTION
Fixes #713 

Adds the new Therapeutics dataset with a `with_covid_therapeutics` study definition query function, as described in #713 

```
covid_therapeutics = patients.with_covid_therapeutics(
	returning = "date",
	with_these_statuses = status_codelist,
	with_these_therapeutics = therapeutic_codelist,
	with_these_indications = indication_codelist,
	on_or_after = "index_date",
	date_format ="YYYY-MM-DD",
        return_first_match_in_period = True,
)
```
Note that there are some duplicate rows for patients, which aer probably not valid, and some "bad" dates that are probably typos (e.g. year 5202).   I'm not excluding or attempting to fix any of these - for now Iwell leave that to the researcher to exclude by setting a sensible date range to filter on, and by creating variables to target specific therapeutics of interest
