### PR TITLE
Return number_of_episodes from with_covid_therapeutics

### DIFF
--- a/cohortextractor/patients.py
+++ b/cohortextractor/patients.py
@@ -2649,6 +2649,7 @@ def with_covid_therapeutics(
     # Matching rule
     find_first_match_in_period=None,
     find_last_match_in_period=None,
+    include_date_of_match=False,
     episode_defined_as=None,
     return_expectations=None,
 ):
@@ -2683,6 +2684,7 @@ def with_covid_therapeutics(
         between: as described elsewhere
         find_first_match_in_period: as described elsewhere
         find_last_match_in_period: as described elsewhere
+        include_date_of_match: a boolean indicating if an extra column containing the date of the match should be returned.
         date_format: a string detailing the format of the treatment dates to be returned.
             It can be "YYYY-MM-DD", "YYYY-MM" or "YYYY" and wherever possible the least disclosive data should be
             returned. i.e returning only year is less disclosive than a date with month and year.

--- a/cohortextractor/patients.py
+++ b/cohortextractor/patients.py
@@ -2649,6 +2649,7 @@ def with_covid_therapeutics(
     # Matching rule
     find_first_match_in_period=None,
     find_last_match_in_period=None,
+    episode_defined_as=None,
     return_expectations=None,
 ):
     """
@@ -2675,6 +2676,7 @@ def with_covid_therapeutics(
             * `region`: Region recorded for the therapeutic intervention; note this may be different
               to the patient's region
             * `number_of_matches_in_period`
+            * `number_of_episodes`
 
         on_or_before: as described elsewhere
         on_or_after: as described elsewhere
@@ -2684,6 +2686,7 @@ def with_covid_therapeutics(
         date_format: a string detailing the format of the treatment dates to be returned.
             It can be "YYYY-MM-DD", "YYYY-MM" or "YYYY" and wherever possible the least disclosive data should be
             returned. i.e returning only year is less disclosive than a date with month and year.
+        episode_defined_as: a string expression indicating how an episode should be defined (used when `returning`="number_of_episodes")
         return_expectations: as described elsewhere
 
     Example:

--- a/tests/test_tpp_backend.py
+++ b/tests/test_tpp_backend.py
@@ -4907,6 +4907,7 @@ def test_with_covid_therapeutics():
             find_first_match_in_period=True,
             returning="risk_group",
             date_format="YYYY-MM",
+            include_date_of_match=True,  # includes a first_risk_group_date column with YYYY-MM format only
         ),
         latest_region=patients.with_covid_therapeutics(
             find_last_match_in_period=True,
@@ -5004,6 +5005,7 @@ def test_with_covid_therapeutics():
         indication_list_match=["2021-12-10", "2021-12-09"],
         indication_list_match_therapeutic=["Casirivimab,imdevimab", "Remdesivir"],
         non_hospitalised_approved_cas_or_mol=["2021-12-10", ""],
+        first_risk_group_date=["2021-12", "2021-12"],
     )
     # risk groups are joined across the 3 columns with ",". Nulls and empty strings are ignored.
     # groups that are not in the ALLOWED_RISK_GROUPS are replaced with "other"


### PR DESCRIPTION
Fixes #733 
Adds the option to return number_of_episodes, in the same way as `with_these_clinical_events` and `with_these _medications`