### PR TITLE
clamp all max dates

### DIFF
--- a/requirements.dev.txt
+++ b/requirements.dev.txt
@@ -6,7 +6,7 @@
 #
 attrs==21.2.0
     # via pytest
-backports.entry-points-selectable==1.1.1
+backports-entry-points-selectable==1.1.1
     # via virtualenv
 black==21.12b0
     # via -r requirements.dev.in
@@ -43,7 +43,7 @@ pathspec==0.9.0
     # via black
 pep517==0.12.0
     # via pip-tools
-pip-tools==6.4.0
+pip-tools==6.5.1
     # via -r requirements.dev.in
 platformdirs==2.4.0
     # via

--- a/run.sh
+++ b/run.sh
@@ -19,4 +19,7 @@ fi
 ENV=${ENV:-dev}
 WORKSPACE=${WORKSPACE:-$PWD}
 
+export DOCKER_BUILDKIT=1
+export COMPOSE_DOCKER_CLI_BUILD=1
+
 exec docker-compose run --rm -v "$WORKSPACE:/workspace" "$ENV" "$@"


### PR DESCRIPTION
- fix: driveby fix to make run.sh build the docker image with buildkit
- fix: update pip/pip-tools due to breakage
- fix: clamp all dates to pandas min/max
