### PR TITLE
Support returning total bed days and total critical care days from patients.admitted_to_hospital

### DIFF
--- a/cohortextractor/patients.py
+++ b/cohortextractor/patients.py
@@ -2387,6 +2387,7 @@ def admitted_to_hospital(
             * `days_in_critical_care`: number of days in critical care during spell,
             * `administrative_category`: private vs NHS funded treatment,
             * `duration_of_elective_wait`: days on waiting list for planned procedures (use with caution).
+            * `total_bed_days_in_period`: total number of bed days for all admissisions during the time period specified
 
         find_first_match_in_period: a boolean that indicates if the data returned is first event
             if there are multiple matches within the time period

--- a/cohortextractor/patients.py
+++ b/cohortextractor/patients.py
@@ -2387,7 +2387,8 @@ def admitted_to_hospital(
             * `days_in_critical_care`: number of days in critical care during spell,
             * `administrative_category`: private vs NHS funded treatment,
             * `duration_of_elective_wait`: days on waiting list for planned procedures (use with caution).
-            * `total_bed_days_in_period`: total number of bed days for all admissisions during the time period specified
+            * `total_bed_days_in_period`: total number of bed days for all admissisions during the time period specified.
+            * `total_critical_care_days_in_period`: total number of critical care days for all admissisions during the time period specified.
 
         find_first_match_in_period: a boolean that indicates if the data returned is first event
             if there are multiple matches within the time period

--- a/cohortextractor/process_covariate_definitions.py
+++ b/cohortextractor/process_covariate_definitions.py
@@ -803,6 +803,7 @@ class GetColumnType:
             "stp_code": "str",
             "symptomatic": "str",
             "therapeutic": "str",
+            "total_bed_days_in_period": "int",
             "underlying_cause_of_death": "str",
             "upper_bound": "float",
             "variant": "str",

--- a/cohortextractor/process_covariate_definitions.py
+++ b/cohortextractor/process_covariate_definitions.py
@@ -804,6 +804,7 @@ class GetColumnType:
             "symptomatic": "str",
             "therapeutic": "str",
             "total_bed_days_in_period": "int",
+            "total_critical_care_days_in_period": "int",
             "underlying_cause_of_death": "str",
             "upper_bound": "float",
             "variant": "str",

--- a/cohortextractor/tpp_backend.py
+++ b/cohortextractor/tpp_backend.py
@@ -2410,6 +2410,16 @@ class TPPBackend:
             "administrative_category": "Administrative_Category",
             "duration_of_elective_wait": "Duration_of_Elective_Wait",
         }
+
+        if returning == "total_bed_days_in_period":
+            # Check unhandled arguments are unused
+            assert (
+                not find_first_match_in_period
+            ), f"Cannot use 'find_first_match_in_period' when returning '{returning}'"
+            assert (
+                not find_last_match_in_period
+            ), f"Cannot use 'find_last_match_in_period' when returning '{returning}'"
+
         column_conditions = {}
         for column in supported_columns.keys():
             keyword = f"with_{column}"
@@ -2426,6 +2436,7 @@ class TPPBackend:
             ordering = "DESC"
             date_aggregate = "MAX"
 
+        use_sum_query = False
         if returning == "binary_flag":
             returning_column = "1"
             use_partition_query = False
@@ -2441,6 +2452,14 @@ class TPPBackend:
         elif returning == "primary_diagnosis":
             returning_column = "Spell_Primary_Diagnosis"
             use_partition_query = True
+        elif returning == "total_bed_days_in_period":
+            # We need to return total bed DAYS from the column Der_Spell_LoS, which represents
+            # length of stay in NIGHTS (0 represents one day's stay)
+            # In case of duplicate spells that start on the same date, we take the
+            # max value by admission date
+            returning_column = "MAX(Der_Spell_LoS)"
+            use_sum_query = True
+            use_partition_query = False
         elif returning in supported_columns:
             returning_column = supported_columns[returning]
             use_partition_query = True
@@ -2514,6 +2533,22 @@ class TPPBackend:
               WHERE {conditions}
             ) t
             WHERE rownum = 1
+            """
+        elif use_sum_query:
+            sql = f"""
+            SELECT patient_id, SUM({returning} + 1) AS {returning}
+            FROM (
+              SELECT
+                APCS.Patient_ID AS patient_id,
+                {returning_column} AS {returning}
+                FROM APCS
+                INNER JOIN APCS_Der
+                  ON APCS.APCS_Ident = APCS_Der.APCS_Ident
+                {date_joins}
+                WHERE {conditions}
+                GROUP BY APCS.Patient_ID, APCS.Admission_Date
+              ) t
+            GROUP BY patient_id
             """
         else:
             sql = f"""

--- a/tests/test_tpp_backend.py
+++ b/tests/test_tpp_backend.py
@@ -3470,7 +3470,11 @@ def test_patients_admitted_to_hospital():
                         Der_Diagnosis_All="||EEEE ,XXXE, XXXF",
                         Der_Procedure_All="||EEEE ,YYYE, YYYF",
                         Der_Spell_LoS="2",
-                        APCS_Der=APCS_Der(Patient_ID=4, Spell_Primary_Diagnosis="EEEE"),
+                        APCS_Der=APCS_Der(
+                            Patient_ID=4,
+                            Spell_Primary_Diagnosis="EEEE",
+                            Spell_PbR_CC_Day="3",
+                        ),
                     ),
                     # duplicate admission date; count only the longest stay
                     APCS(
@@ -3480,7 +3484,11 @@ def test_patients_admitted_to_hospital():
                         Der_Diagnosis_All="||FFFF ,XXXF, XXXG",
                         Der_Procedure_All="||FFFF ,YYYF, YYYG",
                         Der_Spell_LoS="2",
-                        APCS_Der=APCS_Der(Patient_ID=4, Spell_Primary_Diagnosis="FFFF"),
+                        APCS_Der=APCS_Der(
+                            Patient_ID=4,
+                            Spell_Primary_Diagnosis="FFFF",
+                            Spell_PbR_CC_Day="1",
+                        ),
                     ),
                     APCS(
                         APCS_Ident=7,
@@ -3489,7 +3497,10 @@ def test_patients_admitted_to_hospital():
                         Der_Diagnosis_All="||FFFF ,XXXF, XXXG",
                         Der_Procedure_All="||FFFF ,YYYF, YYYG",
                         Der_Spell_LoS="1",
-                        APCS_Der=APCS_Der(Patient_ID=4, Spell_Primary_Diagnosis="FFFF"),
+                        APCS_Der=APCS_Der(
+                            Patient_ID=4,
+                            Spell_Primary_Diagnosis="FFFF",
+                        ),
                     ),
                 ],
             ),
@@ -3591,6 +3602,15 @@ def test_patients_admitted_to_hospital():
             with_these_primary_diagnoses=codelist(["AAA"], "icd10"),
             returning="total_bed_days_in_period",
         ),
+        total_critical_care_days=patients.admitted_to_hospital(
+            on_or_after="2020-02-01",
+            returning="total_critical_care_days_in_period",
+        ),
+        total_critical_care_days_with_primary_diagnoses=patients.admitted_to_hospital(
+            on_or_after="2020-01-01",
+            with_these_primary_diagnoses=codelist(["AAA"], "icd10"),
+            returning="total_critical_care_days_in_period",
+        ),
     )
 
     assert_results(
@@ -3614,6 +3634,8 @@ def test_patients_admitted_to_hospital():
         primary_diagnosis_prefix=["0", "1", "0", "0"],
         total_bed_days=["0", "0", "3", "9"],
         total_bed_days_with_primary_diagnoses=["0", "3", "0", "0"],
+        total_critical_care_days=["0", "0", "0", "9"],
+        total_critical_care_days_with_primary_diagnoses=["0", "3", "0", "0"],
     )
 
 

--- a/tests/test_tpp_backend.py
+++ b/tests/test_tpp_backend.py
@@ -3403,6 +3403,7 @@ def test_patients_admitted_to_hospital():
                         Discharge_Destination="11",
                         Source_of_Admission="2A",
                         Admission_Method="11",
+                        Der_Spell_LoS="2",
                         APCS_Der=APCS_Der(
                             Patient_ID=2,
                             Spell_Primary_Diagnosis="AAAA",
@@ -3424,6 +3425,7 @@ def test_patients_admitted_to_hospital():
                         Discharge_Destination="99",
                         Source_of_Admission="2A",
                         Admission_Method="50",
+                        Der_Spell_LoS="2",
                         APCS_Der=APCS_Der(
                             Patient_ID=3,
                             Spell_Primary_Diagnosis="BBBB",
@@ -3436,6 +3438,7 @@ def test_patients_admitted_to_hospital():
                         Discharge_Date="2020-04-01",
                         Der_Diagnosis_All="||CCCC ,XXXC, XXXD",
                         Der_Procedure_All="||CCCC ,YYYC, YYYD",
+                        Der_Spell_LoS="2",
                         APCS_Der=APCS_Der(Patient_ID=3, Spell_Primary_Diagnosis="CCCC"),
                     ),
                 ],
@@ -3453,6 +3456,7 @@ def test_patients_admitted_to_hospital():
                         Discharge_Destination="11",
                         Source_of_Admission="3B",
                         Admission_Method="99",
+                        Der_Spell_LoS="2",
                         APCS_Der=APCS_Der(
                             Patient_ID=4,
                             Spell_Primary_Diagnosis="DDDD",
@@ -3465,14 +3469,26 @@ def test_patients_admitted_to_hospital():
                         Discharge_Date="2020-06-01",
                         Der_Diagnosis_All="||EEEE ,XXXE, XXXF",
                         Der_Procedure_All="||EEEE ,YYYE, YYYF",
+                        Der_Spell_LoS="2",
                         APCS_Der=APCS_Der(Patient_ID=4, Spell_Primary_Diagnosis="EEEE"),
                     ),
+                    # duplicate admission date; count only the longest stay
                     APCS(
                         APCS_Ident=6,
                         Admission_Date="2020-07-01",
                         Discharge_Date="2020-08-01",
                         Der_Diagnosis_All="||FFFF ,XXXF, XXXG",
                         Der_Procedure_All="||FFFF ,YYYF, YYYG",
+                        Der_Spell_LoS="2",
+                        APCS_Der=APCS_Der(Patient_ID=4, Spell_Primary_Diagnosis="FFFF"),
+                    ),
+                    APCS(
+                        APCS_Ident=7,
+                        Admission_Date="2020-07-01",
+                        Discharge_Date="2020-07-02",
+                        Der_Diagnosis_All="||FFFF ,XXXF, XXXG",
+                        Der_Procedure_All="||FFFF ,YYYF, YYYG",
+                        Der_Spell_LoS="1",
                         APCS_Der=APCS_Der(Patient_ID=4, Spell_Primary_Diagnosis="FFFF"),
                     ),
                 ],
@@ -3566,12 +3582,21 @@ def test_patients_admitted_to_hospital():
             returning="binary_flag",
             with_these_primary_diagnoses=codelist(["AAA"], "icd10"),
         ),
+        total_bed_days=patients.admitted_to_hospital(
+            on_or_after="2020-02-01",
+            returning="total_bed_days_in_period",
+        ),
+        total_bed_days_with_primary_diagnoses=patients.admitted_to_hospital(
+            on_or_after="2020-01-01",
+            with_these_primary_diagnoses=codelist(["AAA"], "icd10"),
+            returning="total_bed_days_in_period",
+        ),
     )
 
     assert_results(
         study.to_dicts(),
         admitted=["0", "0", "1", "1"],
-        count=["0", "0", "1", "3"],
+        count=["0", "0", "1", "4"],
         first_date_admitted=["", "", "2020-03-01", "2020-03-01"],
         last_date_admitted=["", "", "2020-03-01", "2020-07-01"],
         first_date_discharged=["", "", "2020-04-01", "2020-04-01"],
@@ -3579,7 +3604,7 @@ def test_patients_admitted_to_hospital():
         with_particular_primary_diagnosis=["0", "0", "0", "1"],
         with_particular_diagnoses_1=["0", "0", "1", "1"],
         with_particular_diagnoses_2=["0", "0", "0", "2"],
-        with_particular_diagnoses_3=["0", "0", "1", "3"],
+        with_particular_diagnoses_3=["0", "0", "1", "4"],
         with_particular_diagnoses_4=["0", "0", "1", "2"],
         with_particular_procedures=["0", "0", "1", "2"],
         first_primary_diagnosis=["", "", "CCCC", "DDDD"],
@@ -3587,6 +3612,8 @@ def test_patients_admitted_to_hospital():
         discharge_dest=["", "11", "99", ""],
         critical_care_days=["", "3", "", "5"],
         primary_diagnosis_prefix=["0", "1", "0", "0"],
+        total_bed_days=["0", "0", "3", "9"],
+        total_bed_days_with_primary_diagnoses=["0", "3", "0", "0"],
     )
 
 

--- a/tests/tpp_backend_setup.py
+++ b/tests/tpp_backend_setup.py
@@ -742,6 +742,7 @@ class APCS(Base):
     Der_Admit_Treatment_Function_Code = Column(String)
     Administrative_Category = Column(String)
     Duration_of_Elective_Wait = Column(String)
+    Der_Spell_LoS = Column(Integer)
 
 
 class APCS_Der(Base):


### PR DESCRIPTION
Fixes #742 

`patients.admitted_to_hospital` already returns `days_in_critical_care`, however this will return the number of days for the first or last matching admission.  

This allows the return options of `total_critical_care_days_in_period` and `total_bed_days_in_period` by summing the days for all admissions during the period.  In the case where there are two or more admissions recorded with the same admission date, we take the max number of days to avoid counting the sames days more than once.

For `total_bed_days_in_period`, the return value required is number of days, but the data recorded is number of nights (sometimes 0, which counts as one bed day).
