### PR TITLE
fix: disambiguate column references in emis registered_as_of

### DIFF
--- a/cohortextractor/emis_backend.py
+++ b/cohortextractor/emis_backend.py
@@ -862,7 +862,7 @@ class EMISBackend:
         return f"""
             SELECT
                 {self.patient_no_duplicates_table}.registration_id,
-                hashed_organisation,
+                {self.patient_no_duplicates_table}.hashed_organisation,
                 1 AS value
             FROM {self.patient_no_duplicates_table}
             {date_joins}


### PR DESCRIPTION
This allows a date variable to be passed to `registered_as_of` in the emis backend, e.g. to get all patients registered on the date of death as recorded in ONS (with the caveat that EMIS registrations are limited to just the current/latest registration):

```
study = StudyDefinition(
        ons_death_date=patients.died_from_any_cause(
            returning="date_of_death", date_format="YYYY-MM-DD"
        ),
        population=patients.registered_as_of("ons_death_date"),
)
```