### PR TITLE
fix: fix dta exports and feather compression

### DIFF
--- a/cohortextractor/pandas_utils.py
+++ b/cohortextractor/pandas_utils.py
@@ -13,7 +13,8 @@ def dataframe_to_file(df, filename):
     if filename.endswith(".csv") or filename.endswith(".csv.gz"):
         df.to_csv(filename, index=False)
     elif filename.endswith(".feather"):
-        df.to_feather(filename)
+        # zstd is a better option that the default lz4 compression
+        df.to_feather(filename, compression="zstd")
     elif filename.endswith(".dta") or filename.endswith(".dta.gz"):
         # Make a shallow copy of the dataframe so we can replace certain
         # columns without duplicating the entire thing in memory
@@ -31,7 +32,11 @@ def dataframe_to_file(df, filename):
             for (column, dtype) in df.dtypes.items()
             if dtype.name == "datetime64[ns]"
         }
-        df.to_stata(filename, write_index=False, convert_dates=convert_dates)
+        # to_stata will infer gzip compression if the filename ends in .gz
+        # version 118 is the current recommended version for the version of stata opensafely uses.
+        df.to_stata(
+            filename, version=118, write_index=False, convert_dates=convert_dates
+        )
     else:
         raise RuntimeError(f"Unsupported file format: {filename}")
 

--- a/requirements.prod.txt
+++ b/requirements.prod.txt
@@ -22,14 +22,14 @@ lz4==3.1.3
     # via opensafely-cohort-extractor (setup.py)
 matplotlib==3.2.1
     # via seaborn
-numpy==1.18.1
+numpy==1.22.3
     # via
     #   matplotlib
     #   pandas
     #   pyarrow
     #   scipy
     #   seaborn
-pandas==1.0.1
+pandas==1.4.1
     # via
     #   opensafely-cohort-extractor (setup.py)
     #   seaborn
@@ -47,7 +47,7 @@ python-dateutil==2.8.1
     # via
     #   matplotlib
     #   pandas
-pytz==2019.3
+pytz==2021.3
     # via pandas
 pyyaml==5.4.0
     # via opensafely-cohort-extractor (setup.py)


### PR DESCRIPTION
* bugfix .dta.gz export's were not actually gzip compressed. Upgraded
  pandas to enable this.

* used the more recent version 118 dta format, which supports unicode
  and longer strings.

* feather compression switched to using zstd as it is both smaller on
  disk and equivalent speed to decompress.  Also doesn't require a the
  lz4 dependency, so was removed.

* wrote tests to excercise the above exports
