### PR TITLE
bump black to 22.3.0

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: https://github.com/psf/black
-    rev: 20.8b1
+    rev: 22.3.0
     hooks:
     - id: black
 

--- a/requirements.dev.txt
+++ b/requirements.dev.txt
@@ -8,11 +8,11 @@ attrs==21.2.0
     # via pytest
 backports-entry-points-selectable==1.1.1
     # via virtualenv
-black==21.12b0
+black==22.3.0
     # via -r requirements.dev.in
 cfgv==3.3.1
     # via pre-commit
-click==7.1.2
+click==8.1.0
     # via
     #   -c requirements.prod.txt
     #   black

--- a/requirements.prod.txt
+++ b/requirements.prod.txt
@@ -8,7 +8,7 @@ certifi==2020.4.5.1
     # via requests
 chardet==3.0.4
     # via requests
-click==7.1.2
+click==8.1.0
     # via presto-python-client
 cycler==0.10.0
     # via matplotlib


### PR DESCRIPTION
This bumps black to 22.3.0 to avoid breaking with click 8.1 ([chronicled in this black ticket](https://github.com/psf/black/issues/2964)).