### PR TITLE
fix: convert a single string code to a list

### DIFF
--- a/cohortextractor/tpp_backend.py
+++ b/cohortextractor/tpp_backend.py
@@ -3524,6 +3524,8 @@ def codelist_to_list(codelist):
     if getattr(codelist, "has_categories", False):
         return [code for (code, category) in codelist]
     else:
+        if isinstance(codelist, str):
+            return [codelist]
         return list(codelist)
 
 

--- a/tests/test_tpp_backend.py
+++ b/tests/test_tpp_backend.py
@@ -4585,8 +4585,14 @@ def test_outpatient_appointment_date_returning_binary_flag_with_these_treatment_
         opa=patients.outpatient_appointment_date(
             returning="binary_flag", with_these_treatment_function_codes=["812", "813"]
         ),
+        # we can match a single code, provided as a string
+        opa1=patients.outpatient_appointment_date(
+            returning="binary_flag", with_these_treatment_function_codes="812"
+        ),
     )
-    assert_results(study.to_dicts(), opa=["0", "1", "0", "0"])
+    assert_results(
+        study.to_dicts(), opa=["0", "1", "0", "0"], opa1=["0", "1", "0", "0"]
+    )
 
 
 def test_outpatient_appointment_date_returning_binary_flag_with_these_procedure_codes_exact():


### PR DESCRIPTION
A user wants to match a single code, and provides the argument as a string rather than a list, e.g.
```
rheum_appt_date=patients.outpatient_appointment_date(
        returning="date",
        find_first_match_in_period=True,
        with_these_treatment_function_codes='410',
        date_format="YYYY-MM-DD",
        between=["index_date - 1 year", "index_date"],
        return_expectations={
            "incidence": 0.9,
            "date": {"earliest": year_preceding, "latest": end_date},
        },
    )
```

Previously we assumed (but didn't enforce) that the `with_these_treatment_function_codes` argument is either a codelist, or a list of codes that we can convert into a codelist.  Calling `list(codelist)` on a string argument doesn't raise an error, instead it converted the single code into a list of characters - i.e. `["4", "1", "0"]` in the above example, and opaquely failed to match any 
records in the real data.

Since providing a single code as a string seems like a reasonable thing for a user to expect to be able to do, we now just check if it's a string before converting to a list.