### PR TITLE
fix: Log full SQL on the first index date only

### DIFF
--- a/cohortextractor/cohortextractor.py
+++ b/cohortextractor/cohortextractor.py
@@ -198,6 +198,10 @@ def _generate_cohort(
     if index_date_range:
         log_stats(logger, min_index_date=index_dates[-1], max_index_date=index_dates[0])
 
+    # record if we've logged the SQL for this generate_cohort run
+    # For subsequent runs, we log the timing and the first line of the SQL only, since
+    # the only difference should be the index date
+    sql_logged = False
     for index_date in index_dates:
         log_event = f"generate_cohort for {study_name}"
         if index_date is not None:
@@ -206,6 +210,8 @@ def _generate_cohort(
             if index_date is not None:
                 logger.info(f"Setting index_date to {index_date}")
                 study.set_index_date(index_date)
+                if sql_logged:
+                    study.set_sql_logging(truncate=True)
                 date_suffix = f"_{index_date}"
             else:
                 date_suffix = ""
@@ -223,6 +229,7 @@ def _generate_cohort(
                 logger.info(
                     f"Successfully created cohort and covariates at {output_file}"
                 )
+                sql_logged = True
 
 
 def _generate_date_range(date_range_str):

--- a/cohortextractor/emis_backend.py
+++ b/cohortextractor/emis_backend.py
@@ -50,6 +50,7 @@ class EMISBackend:
         self.temp_table_prefix = self.get_temp_table_prefix()
         self.patient_no_duplicates_table = self.add_table_prefix("patient")
         self.queries = self.get_queries(self.covariate_definitions)
+        self.truncate_sql_logs = False
         logger.info(
             "Initialising EMISBackend", temp_table_prefix=self.temp_table_prefix
         )
@@ -1591,7 +1592,9 @@ class EMISBackend:
         if self._db_connection:
             return self._db_connection
         self._db_connection = LoggingDatabaseConnection(
-            logger, trino_connection_from_url(self.database_url)
+            logger,
+            trino_connection_from_url(self.database_url),
+            truncate=self.truncate_sql_logs,
         )
         return self._db_connection
 

--- a/cohortextractor/study_definition.py
+++ b/cohortextractor/study_definition.py
@@ -46,7 +46,6 @@ class StudyDefinition:
             # can't rely on the backend to validate the study definition for us
             self.validate_study_definition()
             self.backend = None
-
         self.log_initial_stats(self._original_covariates)
 
     def log_initial_stats(self, covariate_definitions):
@@ -86,6 +85,10 @@ class StudyDefinition:
         if self.backend:
             log_stats(logger, resetting_backend_index_date=index_date)
             self.recreate_backend()
+
+    def set_sql_logging(self, truncate=False):
+        if self.backend:
+            self.backend.truncate_sql_logs = truncate
 
     def to_file(
         self, filename, expectations_population=False, dummy_data_file=None, **kwargs

--- a/cohortextractor/tpp_backend.py
+++ b/cohortextractor/tpp_backend.py
@@ -46,6 +46,7 @@ class TPPBackend:
         self._therapeutics_table_name = None
         self._ons_cis_table_name = None
         self.queries = self.get_queries(self.covariate_definitions)
+        self.truncate_sql_logs = False
 
     def to_file(self, filename):
         queries = list(self.queries)
@@ -272,7 +273,9 @@ class TPPBackend:
             else:
                 self._db_connection.close()
         self._db_connection = LoggingDatabaseConnection(
-            logger, mssql_dbapi_connection_from_url(self.database_url)
+            logger,
+            mssql_dbapi_connection_from_url(self.database_url),
+            truncate=self.truncate_sql_logs,
         )
         return self._db_connection
 


### PR DESCRIPTION
If there is a range of index dates, the executed SQL is identical for each pass, with the exception of the index date string.  Logging the full SQL each time isn't informative and just inflates the logs.  Instead, log it in full for the first index date, and truncate it to the first line for subsequent index dates, which should still allow us to identify the specific SQL executed when a job failed or was particularly slow, even if we have to look back to the corresponding line for the first index date to find it.