### PR TITLE
Exit codes for specific database errors

### DIFF
--- a/cohortextractor/cohortextractor.py
+++ b/cohortextractor/cohortextractor.py
@@ -774,24 +774,27 @@ def main():
             print(f"Dummy data error: {e}")
             sys.exit(1)
         except Exception as e:
-            traceback.print_exc()
             # Checking for "DatabaseError" in the MRO means we can identify database errors without
             # referencing a specific driver.  Both pymssql and presto/trino-python-client raise
             # exceptions derived from a DatabaseError parent class
-            if "DatabaseError" in str(e.__class__.mro()):
-                # Exit with specific exit codes to help identify known issues
-                if "Unexpected EOF from the server" in str(e):
-                    logger.error(f"Intermittent database error: {e}")
-                    sys.exit(3)
-                if "Invalid object name 'CodedEvent_SNOMED'" in str(e):
-                    logger.error(
-                        "CodedEvent_SNOMED table is currently not available.\n"
-                        "This is likely due to regular database maintenance."
-                    )
-                    sys.exit(4)
-                logger.error(f"Database error: {e}")
-                sys.exit(5)
-            sys.exit(1)
+
+            # Ignore errors which don't look like database errors
+            if "DatabaseError" not in str(e.__class__.mro()):
+                raise
+
+            traceback.print_exc()
+            # Exit with specific exit codes to help identify known issues
+            if "Unexpected EOF from the server" in str(e):
+                logger.error(f"Intermittent database error: {e}")
+                sys.exit(3)
+            if "Invalid object name 'CodedEvent_SNOMED'" in str(e):
+                logger.error(
+                    "CodedEvent_SNOMED table is currently not available.\n"
+                    "This is likely due to regular database maintenance."
+                )
+                sys.exit(4)
+            logger.error(f"Database error: {e}")
+            sys.exit(5)
 
     elif options.which == "generate_measures":
         generate_measures(

--- a/cohortextractor/mssql_utils.py
+++ b/cohortextractor/mssql_utils.py
@@ -33,10 +33,12 @@ def mssql_dbapi_connection_from_url(url):
     # database driver installed (which complicates local installing).
     params = mssql_connection_params_from_url(url)
 
-    # For more background on why we use cTDS and why we support multiple
+    # For more background on why we historically used cTDS and why we support multiple
     # database drivers see:
     # https://github.com/opensafely/cohort-extractor/pull/286
     #
+    # And for background on the switch to pymssql for both testing and production
+    # https://github.com/opensafely-core/cohort-extractor/issues/704
     try:
         import pymssql
     except ImportError:
@@ -61,11 +63,8 @@ def mssql_dbapi_connection_from_url(url):
     raise ImportError(
         "Unable to import database driver, tried `pymssql`, `ctds` and `pyodbc`\n"
         "\n"
-        "We use `ctds` in production. If you are on Linux the correct version is "
-        "specified in the `requirements.prod.txt` file.\n"
-        "\n"
-        "Installation instructions for other platforms can be found at:\n"
-        "https://zillow.github.io/ctds/install.html"
+        "We use `pymssql` in production. The correct version is specified in "
+        "the `requirements.prod.txt` file."
     )
 
 

--- a/cohortextractor/mssql_utils.py
+++ b/cohortextractor/mssql_utils.py
@@ -193,3 +193,23 @@ class BatchFetcher:
                     time.sleep(sleep)
                     sleep *= self.backoff_factor
                     self.cursor = None
+
+
+def database_exceptions():
+    """
+    Returns specific database errors we're interested in catching
+
+    We avoid importing this immediately for similar reasons described above,
+    so we can create a TPPBackend instance without needing a MSSQL
+    database driver installed
+    """
+    try:
+        import pymssql
+
+        return (
+            pymssql._pymssql.OperationalError,
+            pymssql._pymssql.ProgrammingError,
+            pymssql._pymssql.IntegrityError,
+        )
+    except ImportError:
+        return ()

--- a/cohortextractor/mssql_utils.py
+++ b/cohortextractor/mssql_utils.py
@@ -193,23 +193,3 @@ class BatchFetcher:
                     time.sleep(sleep)
                     sleep *= self.backoff_factor
                     self.cursor = None
-
-
-def database_exceptions():
-    """
-    Returns specific database errors we're interested in catching
-
-    We avoid importing this immediately for similar reasons described above,
-    so we can create a TPPBackend instance without needing a MSSQL
-    database driver installed
-    """
-    try:
-        import pymssql
-
-        return (
-            pymssql._pymssql.OperationalError,
-            pymssql._pymssql.ProgrammingError,
-            pymssql._pymssql.IntegrityError,
-        )
-    except ImportError:
-        return ()


### PR DESCRIPTION
fixes #776 

Catches [pymssql errors](https://github.com/pymssql/pymssql/blob/f486f7d79bd2583eba96323cdeca34eb8f14cd2a/src/pymssql/_pymssql.pyx#L117); of the ones listed there, `OperationalError`, `ProgrammingError` and `IntegrityError` seem to be the ones actually raised by pymssql.  

The 2 specific errors from issue #776 are: 

- `Unexpected EOF from the server` (`OperationalError`)
- `Invalid object name 'CodedEvent_SNOMED'` when the snomed table is being built (`ProgrammingError`).  

Other database errors should raise one of these, and I've included `IntegrityError` just in case so that would also get caught as a general database error code.

