### PR TITLE
fix: Log measure dates as strings

### DIFF
--- a/cohortextractor/cohortextractor.py
+++ b/cohortextractor/cohortextractor.py
@@ -348,11 +348,12 @@ def _generate_measures(
             continue
         filepath = os.path.join(output_dir, file)
         logger.info(f"Calculating measures for {filepath}")
+        date_string_for_logs = date.strftime("%Y-%m-%d")
         with log_execution_time(
             logger,
             description="generate_measures",
             input_file=filepath,
-            date=date,
+            date=date_string_for_logs,
             study_definition=study_name,
         ):
             patient_df = None
@@ -371,28 +372,28 @@ def _generate_measures(
                         logger,
                         description="Load patient dataframe for measures",
                         input_file=filepath,
-                        date=date,
+                        date=date_string_for_logs,
                     ):
                         patient_df = _load_dataframe_for_measures(filepath, measures)
                         log_stats(
                             logger,
                             dataframe="patient_df",
                             measure_id=measure.id,
-                            date=date,
+                            date=date_string_for_logs,
                             memory=patient_df.memory_usage(deep=True).sum(),
                         )
                 with log_execution_time(
                     logger,
                     description="Calculate measure",
                     measure_id=measure.id,
-                    date=date,
+                    date=date_string_for_logs,
                 ):
                     measure_df = measure.calculate(patient_df, _report)
                 log_stats(
                     logger,
                     dataframe="measure_df",
                     measure_id=measure.id,
-                    date=date,
+                    date=date_string_for_logs,
                     memory=measure_df.memory_usage(deep=True).sum(),
                 )
                 measure_df.to_csv(output_file, index=False)

--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -1,5 +1,4 @@
 import re
-from datetime import datetime
 from unittest.mock import patch
 
 import pytest
@@ -675,7 +674,7 @@ def test_stats_logging_generate_measures(
     stats_logs = get_stats_logs(logger.entries)
     memory_logs = get_logs_by_key(stats_logs, "memory")
 
-    measure_date = datetime(2020, 1, 1).date()
+    measure_date = "2020-01-01"
     expected_timing_logs = [
         dict(
             description="generate_measures",


### PR DESCRIPTION
Measure dates were being logged directly, which meant the literal string e.g. "datetime(2022, 5, 1)" in logs.  Convert them to date strings in the same format as index dates for better log parsing.