### PR TITLE
Improve timing logs

### DIFF
--- a/cohortextractor/log_utils.py
+++ b/cohortextractor/log_utils.py
@@ -3,7 +3,7 @@ import logging.config
 import os
 from contextlib import contextmanager
 from datetime import timedelta
-from time import process_time
+from time import monotonic
 
 import structlog
 
@@ -81,7 +81,7 @@ def log_execution_time(logger, **log_kwargs):
     sql = log_kwargs.pop("sql", None)
     truncate_all_sql = log_kwargs.pop("truncate", False)
 
-    start = process_time()
+    start = monotonic()
     # log that we're starting timing
     log_stats(logger, timing="start", time=start, **log_kwargs)
 
@@ -116,7 +116,7 @@ def log_execution_time(logger, **log_kwargs):
     else:
         log_kwargs["state"] = "ok"
     finally:
-        stop = process_time()
+        stop = monotonic()
         elapsed_time = stop - start
         log_kwargs.update(
             timing="stop",

--- a/cohortextractor/mssql_utils.py
+++ b/cohortextractor/mssql_utils.py
@@ -5,6 +5,8 @@ from urllib.parse import unquote, urlparse
 
 import structlog
 
+from .log_utils import log_execution_time
+
 # Some drivers warn about the use of features marked "optional" in the DB-ABI
 # spec, using a standardised set of warnings. See:
 # https://www.python.org/dev/peps/pep-0249/#optional-db-api-extensions
@@ -181,7 +183,11 @@ class BatchFetcher:
                 if self.cursor is None:
                     self.cursor = self.get_cursor()
                 self.cursor.execute(query)
-                return self.cursor.fetchall()
+                with log_execution_time(
+                    logger, description=f"Fetch batched results {where}"
+                ):
+                    results = self.cursor.fetchall()
+                return results
             # We can't be more specific than this because we don't know what class
             # of cursor object we'll be passed
             except Exception:

--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -359,6 +359,18 @@ def test_stats_logging_generate_cohort(
         ),
         dict(description=None, timing="stop", state="ok", timing_id=start_counter + 8),
         dict(
+            description="Fetch batched results ",
+            timing="start",
+            state="started",
+            timing_id=start_counter + 9,
+        ),
+        dict(
+            description="Fetch batched results ",
+            timing="stop",
+            state="ok",
+            timing_id=start_counter + 9,
+        ),
+        dict(
             description=f"{write_to_file_log} {tmp_path}/input.{output_format}",
             timing="stop",
             state="ok",
@@ -368,18 +380,18 @@ def test_stats_logging_generate_cohort(
             description="Deleting '#final_output'",
             timing="start",
             state="started",
-            timing_id=start_counter + 9,
+            timing_id=start_counter + 10,
         ),
         dict(
             sql="DROP TABLE #final_output",
             is_truncated=False,
-            timing_id=start_counter + 9,
+            timing_id=start_counter + 10,
         ),
         dict(
             description="Deleting '#final_output'",
             timing="stop",
             state="ok",
-            timing_id=start_counter + 9,
+            timing_id=start_counter + 10,
         ),
         # logging the overall timing for the cohort generation
         dict(
@@ -573,6 +585,18 @@ def test_stats_logging_generate_cohort_with_index_dates(
                     timing_id=next_counter + 6,
                 ),
                 dict(
+                    description="Fetch batched results ",
+                    timing="start",
+                    state="started",
+                    timing_id=next_counter + 7,
+                ),
+                dict(
+                    description="Fetch batched results ",
+                    timing="stop",
+                    state="ok",
+                    timing_id=next_counter + 7,
+                ),
+                dict(
                     description=f"write_rows_to_csv {tmp_path}/input_test_{index_date}.csv",
                     timing="stop",
                     state="ok",
@@ -582,18 +606,18 @@ def test_stats_logging_generate_cohort_with_index_dates(
                     description="Deleting '#final_output'",
                     timing="start",
                     state="started",
-                    timing_id=next_counter + 7,
+                    timing_id=next_counter + 8,
                 ),
                 dict(
                     sql="DROP TABLE #final_output",
                     is_truncated=i != 1,
-                    timing_id=next_counter + 7,
+                    timing_id=next_counter + 8,
                 ),
                 dict(
                     description="Deleting '#final_output'",
                     timing="stop",
                     state="ok",
-                    timing_id=next_counter + 7,
+                    timing_id=next_counter + 8,
                 ),
                 # logging the overall timing for the cohort generation
                 dict(
@@ -606,7 +630,7 @@ def test_stats_logging_generate_cohort_with_index_dates(
             ]
         )
         # set next counter to one more than the max for this index date
-        next_counter += 7 + 1
+        next_counter += 8 + 1
 
     # add the log for the end of overall timing for the cohort generation; this should have the same
     # id as the first timing log


### PR DESCRIPTION
- Log timing with `time.monotonic`
- Time the batched `fetchall()` calls