### PR TITLE
feat: support dummy data for generate_codelist_report command

### DIFF
--- a/cohortextractor/cohortextractor.py
+++ b/cohortextractor/cohortextractor.py
@@ -746,7 +746,7 @@ def main():
     generate_codelist_report_parser.add_argument(
         "--output-dir",
         help="Location to store output files",
-        type=str,
+        type=pathlib.Path,
         default="output",
     )
     generate_codelist_report_parser.add_argument(
@@ -763,6 +763,18 @@ def main():
         "--end-date",
         help="End date",
         type=datetime.date.fromisoformat,
+    )
+    generate_codelist_report_parser.add_argument(
+        "--codes",
+        default=16,
+        help="For dummy data, how many codes to use from the codelist",
+        type=int,
+    )
+    generate_codelist_report_parser.add_argument(
+        "--days",
+        default=70,
+        help="For dummy data, how many days of data to generate between start date and end date",
+        type=int,
     )
 
     maintenance_parser = subparsers.add_parser(
@@ -853,6 +865,8 @@ def main():
             options.codelist_path,
             options.start_date,
             options.end_date,
+            options.codes,
+            options.days,
         )
     elif options.which == "cohort_report":
         make_cohort_report(options.input_dir, options.output_dir)

--- a/cohortextractor/generate_codelist_report.py
+++ b/cohortextractor/generate_codelist_report.py
@@ -231,18 +231,20 @@ def generate_dummy_data(output_dir, codelist, start_date, end_date, codes, days)
 
     This is not meant to be realistic, it's for testing the charting and other actions work.
     """
+
+    local_random = random.Random(123)
     rows = []
     rows_list_size = []
 
     total_days = (end_date - start_date).days
 
     # choose `code_count` codes to use from the codelist
-    codes = random.sample(codelist, min(len(codelist), codes))
+    codes = local_random.sample(codelist, min(len(codelist), codes))
     for i, code in enumerate(codes):
         # step from start date to end date in `days` steps, so we have a full date range
         for date_offset in range(0, total_days, max(total_days // days, 1)):
             for practice in range(100):
-                jitter = random.uniform(0.8, 1.2)
+                jitter = local_random.uniform(0.8, 1.2)
                 count = int(
                     (1000 + practice * jitter - 5 * abs(date_offset - total_days))
                     * jitter
@@ -258,7 +260,7 @@ def generate_dummy_data(output_dir, codelist, start_date, end_date, codes, days)
                 )
 
     for practice in range(100):
-        rows_list_size.append([f"{practice:02}", int(random.gauss(2000, 500))])
+        rows_list_size.append([f"{practice:02}", int(local_random.gauss(2000, 500))])
 
     counts = pd.DataFrame(rows, columns=["code", "date", "practice", "num"])
     counts["date"] = pd.to_datetime(counts["date"])


### PR DESCRIPTION
This command does not use study definitions, so we use previously
developed code to embed a default dummy data model for it. This allows
it to be used in local development. Currently, it can only be
run in production.

Note: this work uncovered a bug in the db fixutre cleanup, in that
removing the tables didn't actually work once there was multiple tests
in the module. Rather than figure out the specific deletion order
needed, I just reused the cleanup from the tpp tests.
