### PR TITLE
Fix: use the mapped db table name in additional supported columns for admitted_to_hospital

### DIFF
--- a/cohortextractor/tpp_backend.py
+++ b/cohortextractor/tpp_backend.py
@@ -2537,7 +2537,7 @@ class TPPBackend:
 
         for column_name, column_value in column_conditions.items():
             value_sql = ", ".join(map(quote, to_list(column_value)))
-            conditions.append(f"{column_name} IN ({value_sql})")
+            conditions.append(f"{supported_columns[column_name]} IN ({value_sql})")
 
         if with_these_primary_diagnoses:
             assert with_these_primary_diagnoses.system == "icd10"

--- a/tests/test_tpp_backend.py
+++ b/tests/test_tpp_backend.py
@@ -3478,6 +3478,7 @@ def test_patients_admitted_to_hospital():
                             Spell_Primary_Diagnosis="BBBB",
                             Spell_PbR_CC_Day="4",
                         ),
+                        Der_Admit_Treatment_Function_Code="123",
                     ),
                     APCS(
                         APCS_Ident=3,
@@ -3658,6 +3659,10 @@ def test_patients_admitted_to_hospital():
             with_these_primary_diagnoses=codelist(["AAA"], "icd10"),
             returning="total_critical_care_days_in_period",
         ),
+        with_treatment_admission_function_code=patients.admitted_to_hospital(
+            with_admission_treatment_function_code="123",
+            returning="binary_flag",
+        ),
     )
 
     assert_results(
@@ -3683,6 +3688,7 @@ def test_patients_admitted_to_hospital():
         total_bed_days_with_primary_diagnoses=["0", "3", "0", "0"],
         total_critical_care_days=["0", "0", "0", "9"],
         total_critical_care_days_with_primary_diagnoses=["0", "3", "0", "0"],
+        with_treatment_admission_function_code=["0", "0", "1", "0"],
     )
 
 


### PR DESCRIPTION
Fixes #817 