### PR TITLE
Fx: Allow reserved keywords to be used as variable names

### DIFF
--- a/cohortextractor/tpp_backend.py
+++ b/cohortextractor/tpp_backend.py
@@ -363,7 +363,7 @@ class TPPBackend:
         # Insert `patient_id` as the first column
         output_columns = dict(patient_id=patient_id_expr, **output_columns)
         output_columns_str = ",\n          ".join(
-            f"{expr} AS {name}"
+            f"{expr} AS [{name}]"
             for (name, expr) in output_columns.items()
             if not expr.is_hidden and name != "population"
         )

--- a/tests/test_emis_backend.py
+++ b/tests/test_emis_backend.py
@@ -106,6 +106,22 @@ def test_minimal_study_to_file(tmp_path, format):
     ]
 
 
+def test_minimal_study_with_reserved_keywords():
+    # Test that we can use reserved SQL keywords as study variables
+    session = make_session()
+    patient_1 = Patient(date_of_birth="1980-01-01", gender=1, hashed_organisation="abc")
+    patient_2 = Patient(date_of_birth="1965-01-01", gender=2, hashed_organisation="abc")
+    session.add_all([patient_1, patient_2])
+    session.commit()
+    study = StudyDefinition(
+        population=patients.all(),
+        all=patients.sex(),
+        asc=patients.age_as_of("2020-01-01"),
+    )
+
+    assert_results(study.to_dicts(), all=["M", "F"], asc=["40", "55"])
+
+
 def test_meds():
     session = make_session()
 

--- a/tests/test_tpp_backend.py
+++ b/tests/test_tpp_backend.py
@@ -166,6 +166,22 @@ def test_minimal_study_to_file(tmp_path, format):
     ]
 
 
+def test_minimal_study_with_reserved_keywords():
+    # Test that we can use reserved SQL keywords as study variables
+    session = make_session()
+    patient_1 = Patient(DateOfBirth="1980-01-01", Sex="M")
+    patient_2 = Patient(DateOfBirth="1965-01-01", Sex="F")
+    session.add_all([patient_1, patient_2])
+    session.commit()
+    study = StudyDefinition(
+        population=patients.all(),
+        all=patients.sex(),
+        asc=patients.age_as_of("2020-01-01"),
+    )
+
+    assert_results(study.to_dicts(), all=["M", "F"], asc=["40", "55"])
+
+
 @pytest.mark.parametrize("format", ["csv", "csv.gz", "feather", "dta", "dta.gz"])
 def test_study_to_file_with_therapeutic_risk_groups(tmp_path, format):
     session = make_session()


### PR DESCRIPTION
Using a reserved keyword such as "all" as a variable name in a study definition was resulting in a syntax error.  Now we just wrap the variable names in square brackets (the same delimiter that sqlalchemy uses)