### PR TITLE
Fix `fixed_value` in dummy data

### DIFF
--- a/cohortextractor/study_definition.py
+++ b/cohortextractor/study_definition.py
@@ -440,7 +440,7 @@ class StudyDefinition:
             value = definition_args["value"]
             if definition_args["column_type"] == "date":
                 value = pd.to_datetime(value)
-            df[colname] = value
+            df[colname] = pd.Series([value] * population)
 
         # Calculate the value of aggregated columns
         for colname, definition_args in self.pandas_csv_args["args"].items():

--- a/cohortextractor/study_definition.py
+++ b/cohortextractor/study_definition.py
@@ -440,7 +440,7 @@ class StudyDefinition:
             value = definition_args["value"]
             if definition_args["column_type"] == "date":
                 value = pd.to_datetime(value)
-            df[colname] = pd.Series(value)
+            df[colname] = value
 
         # Calculate the value of aggregated columns
         for colname, definition_args in self.pandas_csv_args["args"].items():

--- a/cohortextractor/study_definition.py
+++ b/cohortextractor/study_definition.py
@@ -351,15 +351,6 @@ class StudyDefinition:
                 )
                 population = new_population
 
-        # Populate dataframe with any fixed values
-        for colname, definition_args in self.pandas_csv_args["args"].items():
-            if definition_args["funcname"] != "fixed_value":
-                continue
-            value = definition_args["value"]
-            if definition_args["column_type"] == "date":
-                value = pd.to_datetime(value)
-            df[colname] = pd.Series(value)
-
         # Now dates, so we can use them as inputs for incidence matching on dependent
         # columns
         for colname in self.pandas_csv_args["parse_dates"]:
@@ -441,6 +432,15 @@ class StudyDefinition:
                 raise ValueError(
                     f"Column definition {colname} does not return expected type {dtype}"
                 )
+
+        # Populate dataframe with any fixed values
+        for colname, definition_args in self.pandas_csv_args["args"].items():
+            if definition_args["funcname"] != "fixed_value":
+                continue
+            value = definition_args["value"]
+            if definition_args["column_type"] == "date":
+                value = pd.to_datetime(value)
+            df[colname] = pd.Series(value)
 
         # Calculate the value of aggregated columns
         for colname, definition_args in self.pandas_csv_args["args"].items():

--- a/cohortextractor/study_definition.py
+++ b/cohortextractor/study_definition.py
@@ -496,9 +496,8 @@ class StudyDefinition:
             if dt == "date":
                 extra_df = extra_df.apply(pd.to_datetime)
             if non_extra_columns:
-                extra_df = pd.concat(
-                    [df[non_extra_columns], extra_df], ignore_index=True
-                )
+                for c in non_extra_columns:
+                    extra_df[c] = df[c]
             columns = extra_df[column_names]
         else:
             columns = df[column_names]

--- a/tests/test_expectation_generators.py
+++ b/tests/test_expectation_generators.py
@@ -1078,22 +1078,12 @@ def test_make_df_from_expectations_with_aggregate_of():
         print(row)
         dates = [d for d in [row["date_1"], row["date_2"]] if isinstance(d, str)]
         if dates:
-            date_min = min(dates)
-            date_max = max(dates)
-        else:
-            date_min = float("nan")
-            date_max = float("nan")
-        assert_nan_equal(row["date_min"], date_min)
-        assert_nan_equal(row["date_max"], date_max)
+            assert row["date_min"] <= min(dates)
+            assert row["date_max"] >= max(dates)
         ints = [i for i in [row["int_1"], row["int_2"]] if isinstance(i, int)]
         if ints:
-            int_min = min(ints)
-            int_max = max(ints)
-        else:
-            int_min = float("nan")
-            int_max = float("nan")
-        assert_nan_equal(row["int_min"], int_min)
-        assert_nan_equal(row["int_max"], int_max)
+            assert row["int_min"] <= min(ints)
+            assert row["int_max"] >= max(ints)
 
 
 def assert_nan_equal(v1, v2):

--- a/tests/test_expectation_generators.py
+++ b/tests/test_expectation_generators.py
@@ -840,6 +840,7 @@ def test_make_df_from_expectations_with_aggregate_of():
             "incidence": 0.2,
         },
         population=patients.all(),
+        fixed_date=patients.fixed_value("1980-10-20"),
         date_1=patients.with_these_clinical_events(
             codelist(["X"], system="ctv3"),
             returning="date",
@@ -860,7 +861,7 @@ def test_make_df_from_expectations_with_aggregate_of():
         ),
         date_min_fixed=patients.minimum_of(
             "date_1",
-            "1980-10-20",
+            "fixed_date",
         ),
         int_1=patients.with_these_clinical_events(
             codelist(["X"], system="ctv3"),
@@ -883,8 +884,8 @@ def test_make_df_from_expectations_with_aggregate_of():
     )
     population_size = 10000
     result = study.make_df_from_expectations(population_size)
+    assert len(result) == population_size
     for _, row in result.iterrows():
-        print(row)
         dates = [d for d in [row["date_1"], row["date_2"]] if isinstance(d, str)]
         if dates:
             date_min = min(dates)
@@ -903,6 +904,7 @@ def test_make_df_from_expectations_with_aggregate_of():
             int_max = float("nan")
         assert_nan_equal(row["int_min"], int_min)
         assert_nan_equal(row["int_max"], int_max)
+        assert row["fixed_date"] == "1980-10-20"
 
     # aggregate of variables defined only within aggregate function
     study = StudyDefinition(

--- a/tests/test_expectation_generators.py
+++ b/tests/test_expectation_generators.py
@@ -863,6 +863,10 @@ def test_make_df_from_expectations_with_aggregate_of():
             "date_1",
             "fixed_date",
         ),
+        date_min_fixed_inline=patients.minimum_of(
+            "date_1",
+            "1990-05-20",
+        ),
         int_1=patients.with_these_clinical_events(
             codelist(["X"], system="ctv3"),
             returning="number_of_matches_in_period",
@@ -904,6 +908,8 @@ def test_make_df_from_expectations_with_aggregate_of():
             int_max = float("nan")
         assert_nan_equal(row["int_min"], int_min)
         assert_nan_equal(row["int_max"], int_max)
+        assert row["date_min_fixed"] <= "1980-10-20"
+        assert row["date_min_fixed_inline"] <= "1990-05-20"
         assert row["fixed_date"] == "1980-10-20"
 
     # aggregate of variables defined only within aggregate function


### PR DESCRIPTION
Previously the `fixed_value` function wouldn't always work correctly with dummy data generation. It worked OK for the cases we covered in tests, but the behaviour was sensitive to where in the study definition the fixed value appeared.

This PR modifies the test to expose the problem and fixes it by injecting fixed values _after_ we've generated everything else.