### PR TITLE
fix: Add warning to with_gp_consultations docs

### DIFF
--- a/cohortextractor/patients.py
+++ b/cohortextractor/patients.py
@@ -1804,6 +1804,15 @@ def with_gp_consultations(
     return_expectations=None,
 ):
     """
+    !!! warning
+    A "consultation" as returned by this function may not actually be a consultation between a health care professional and patient.
+
+    For example, simple administrative tasks such as updating a patient's details may also cause creation of a "consultation" record.
+
+    It is, therefore, extremely unlikely you can use this field to infer anything about real clinician-patient interactions,
+    and it is even more difficult to compare activity between practices as recording behaviour can vary.
+    Some EHRs even delete consultation data for a patient when they switch practice.
+
     These are GP-patient interactions, either in person or via phone/video
     call. The concept of a "consultation" in EHR systems is generally broader
     and might include things like updating a phone number with the


### PR DESCRIPTION
This moves the warning from the bottom of the section to the top.

Addresses part of opensafely-core/opensafely-cli#120

![image](https://user-images.githubusercontent.com/28734/179702182-896673f5-2e85-45f6-8a78-ea4405366318.png)
