### PR TITLE
default to fixed date behaviour

### DIFF
--- a/cohortextractor/cohortextractor.py
+++ b/cohortextractor/cohortextractor.py
@@ -701,8 +701,8 @@ def main():
         action="store_true",
     )
     generate_cohort_parser.add_argument(
-        "--with-end-date-fix",
-        action="store_true",
+        "--without-end-date-fix",
+        action="store_false",
     )
     cohort_method_group = generate_cohort_parser.add_mutually_exclusive_group()
     cohort_method_group.add_argument(

--- a/cohortextractor/cohortextractor.py
+++ b/cohortextractor/cohortextractor.py
@@ -799,10 +799,9 @@ def main():
     elif not hasattr(options, "which"):
         parser.print_help()
     elif options.which == "generate_cohort":
-        # This defaults to False for now (when --with-end-date-fix is not provided) so that
-        # study outputs don't change unexpectedly.  After some more investigation, we'll
-        # change the default to True (via --without-end-date-fix).
-        flags.WITH_END_DATE_FIX = bool(options.with_end_date_fix)
+        # This defaults to True
+        # The old behaviour is configurable via --without-end-date-fix.
+        flags.WITH_END_DATE_FIX = not bool(options.without_end_date_fix)
 
         if options.database_url:
             os.environ["DATABASE_URL"] = options.database_url


### PR DESCRIPTION
Makes default the "date fix" (#845 ) whereby all `datetime`s are cast to `date`s in date comparisons. Previous behaviour (which is considered buggy) optionally available via `--without-end-date-fix`.