### PR TITLE
Add defaults to with_these_medications docstring

### DIFF
--- a/cohortextractor/patients.py
+++ b/cohortextractor/patients.py
@@ -665,8 +665,10 @@ def with_these_medications(
 
         find_first_match_in_period: a boolean indicating if any returned date, code, category, or numeric value
             should be based on the first match in the period.
+            If several matches compare equal, then their IDs are used to break the tie.
         find_last_match_in_period: a boolean indicating if any returned date, code, category, or numeric value
-            should be based on the last match in the period.
+            should be based on the last match in the period. This is the default behaviour.
+            If several matches compare equal, then their IDs are used to break the tie.
         include_date_of_match: a boolean indicating if an extra column should be included in the output.
         date_format: a string detailing the format of the dates to be returned. It can be `YYYY-MM-DD`,
             `YYYY-MM` or `YYYY` and wherever possible the least disclosive data should be returned. i.e returning


### PR DESCRIPTION
Copy missing default and tie-breaking behaviour 
explanation for find_first_match_in_period and 
find_last_match_in_period args from 
with_these_clinical_events to
with_these_medications