### PR TITLE
fix: Fix handling of NaN values

### DIFF
--- a/cohortextractor/emis_backend.py
+++ b/cohortextractor/emis_backend.py
@@ -1,4 +1,5 @@
 import datetime
+import math
 import os
 import re
 import uuid
@@ -1652,7 +1653,10 @@ def is_iso_date(value):
 
 def quote(value, reformat_dates=True):
     if isinstance(value, (int, float)):
-        return str(value)
+        if math.isnan(value):
+            return "NULL"
+        else:
+            return str(value)
 
     value = str(value)
     if reformat_dates:

--- a/cohortextractor/tpp_backend.py
+++ b/cohortextractor/tpp_backend.py
@@ -1,6 +1,7 @@
 import datetime
 import enum
 import hashlib
+import math
 import os
 import re
 import uuid
@@ -3727,7 +3728,10 @@ def is_iso_date(value):
 
 def quote(value, reformat_dates=True):
     if isinstance(value, (int, float)):
-        return str(value)
+        if math.isnan(value):
+            return "NULL"
+        else:
+            return str(value)
     else:
         value = str(value)
         if reformat_dates:

--- a/tests/test_tpp_backend.py
+++ b/tests/test_tpp_backend.py
@@ -5114,6 +5114,23 @@ def test_with_float_value_from_file(patient_ids, tmp_path):
     assert_results(study.to_dicts(), case_bmi=["18.5", "0.0"])
 
 
+def test_with_nan_float_value_from_file(patient_ids, tmp_path):
+    f_path = _to_csv(
+        [
+            {"patient_id": patient_ids[0], "bmi": float("nan")},
+            {"patient_id": patient_ids[1], "bmi": 18.5},
+        ],
+        tmp_path,
+    )
+    study = StudyDefinition(
+        population=patients.all(),
+        case_bmi=patients.with_value_from_file(
+            f_path, returning="bmi", returning_type="float"
+        ),
+    )
+    assert_results(study.to_dicts(), case_bmi=["0.0", "18.5"])
+
+
 def test_with_value_from_file_with_unexpected_file_type():
     with pytest.raises(TypeError):
         StudyDefinition(


### PR DESCRIPTION
These were getting introduced via the `patients.with_value_from_file()`
function when loading data saved using Pandas which encodes missing
values as `NaN`. This resulted in SQL like this:

    INSERT INTO #tmp4_vax_date_covid_1_file (patient_id, vax_date_covid_1) VALUES
    (123456, '20210101'),
    (123457, nan);

Which of course leads to the error:

    Invalid column name 'nan'