### PR TITLE
Support parameterising study definitions

### DIFF
--- a/cohortextractor/__init__.py
+++ b/cohortextractor/__init__.py
@@ -6,6 +6,7 @@ from .codelistlib import (
     combine_codelists,
     filter_codes_by_category,
 )
+from .exceptions import MissingParameterError
 from .log_utils import init_logging
 from .measure import Measure
 from .study_definition import StudyDefinition
@@ -22,4 +23,18 @@ __all__ = [
     "codelist_from_csv",
     "filter_codes_by_category",
     "combine_codelists",
+    "params",
 ]
+
+
+# Custom dict subclass so we can raise more helpful errors for missing params
+class ParamDict(dict):
+    def __getitem__(self, key):
+        try:
+            return super().__getitem__(key)
+        except KeyError:
+            raise MissingParameterError(key)
+
+
+# Global for passing `--param` arguments from command line to study definitions
+params = ParamDict()

--- a/cohortextractor/exceptions.py
+++ b/cohortextractor/exceptions.py
@@ -4,3 +4,7 @@ class ValidationError(Exception):
 
 class DummyDataValidationError(ValidationError):
     human_name = "Dummy data error"
+
+
+class MissingParameterError(ValidationError):
+    human_name = "Missing --param error"

--- a/cohortextractor/exceptions.py
+++ b/cohortextractor/exceptions.py
@@ -1,2 +1,6 @@
-class DummyDataValidationError(Exception):
-    pass
+class ValidationError(Exception):
+    human_name = "Validation error"
+
+
+class DummyDataValidationError(ValidationError):
+    human_name = "Dummy data error"

--- a/tests/fixtures/studies/test_params/analysis/study_definition.py
+++ b/tests/fixtures/studies/test_params/analysis/study_definition.py
@@ -1,0 +1,24 @@
+from cohortextractor import StudyDefinition, params, patients
+
+age_suffix = params["age_suffix"]
+sex_suffix = params["sex_suffix"]
+
+study = StudyDefinition(
+    default_expectations={"date": {"earliest": "1900-01-01", "latest": "2020-01-01"}},
+    population=patients.all(),
+    **{
+        f"age_{age_suffix}": patients.age_as_of(
+            "2020-01-01",
+            return_expectations={
+                "rate": "universal",
+                "int": {"distribution": "population_ages"},
+            },
+        ),
+        f"sex_{sex_suffix}": patients.sex(
+            return_expectations={
+                "rate": "universal",
+                "category": {"ratios": {"M": 0.5, "F": 0.5}},
+            }
+        ),
+    },
+)

--- a/tests/test_cohortextractor.py
+++ b/tests/test_cohortextractor.py
@@ -5,6 +5,7 @@ from unittest.mock import patch
 
 import pytest
 
+from cohortextractor import MissingParameterError, params
 from cohortextractor.cohortextractor import flags, list_study_definitions, main
 
 
@@ -131,6 +132,7 @@ def test_output_file_args_passed_to_generate_cohort(patch_generate_cohort):
         skip_existing=False,
         output_format="csv.gz",
         output_name="results",
+        params={},
     )
 
 
@@ -146,6 +148,7 @@ def test_multiple_studies_handled_if_no_output_file_option(patch_generate_cohort
         skip_existing=False,
         output_format="feather",
         output_name="input",
+        params={},
     )
     patch_generate_cohort.assert_any_call(
         "output",
@@ -157,4 +160,10 @@ def test_multiple_studies_handled_if_no_output_file_option(patch_generate_cohort
         skip_existing=False,
         output_format="feather",
         output_name="input",
+        params={},
     )
+
+
+def test_params_dict_raises_correct_error():
+    with pytest.raises(MissingParameterError, match="nothere"):
+        params["nothere"]

--- a/tests/test_smoketest.py
+++ b/tests/test_smoketest.py
@@ -164,6 +164,30 @@ def test_patients_from_file(tmp_path):
     assert contents[1][2] == "1"  # boolean
 
 
+def test_passing_params_to_study_definition(tmp_path):
+    population_size = 4
+    _cohortextractor(
+        study="test_params",
+        args=[
+            "generate_cohort",
+            "--expectations-population",
+            str(population_size),
+            "--output-file",
+            tmp_path / "results_with_params.csv",
+            "--param",
+            "age_suffix=one",
+            "--param",
+            "sex_suffix",
+            "=",
+            "two",
+        ],
+    )
+    with open(tmp_path / "results_with_params.csv") as f:
+        contents = list(csv.reader(f))
+    assert len(contents) == population_size + 1
+    assert set(contents[0]) == {"patient_id", "age_one", "sex_two"}
+
+
 def _cohortextractor(study, args):
     study_path = os.path.join(os.path.dirname(__file__), "fixtures", "studies", study)
     cohortextractor_path = os.path.dirname(os.path.dirname(cohortextractor.__file__))


### PR DESCRIPTION
This teaches `generate_cohort` to accept a new, multi-valued `--param` argument e.g.

    cohortextractor generate_cohort --param key1=value1 --param key2=value2 --param key3

The study definition can access these via the `params` dict in the `cohortextractor` module:
```py
from cohortextractor import params
print(params)
# {'key1': 'value1', 'key2': 'value2', 'key3': ''}
```

There was a suggestion earlier of using `--arg` for this, but I think `--param` avoids confusion with other kinds of thing which are also called "arguments", and fits neatly with the term "parameterised study definition".

This was all much harder than it ought to be because implicit in this feature is the need for the output file name to be customised. Previously the output directory and format could be changed, but the file name was determined by the study definition name e.g. `study_definition_test.py` would always produce a file called `<output_dir>/input_test.<extension>`.

So we now support an `--output-file` argument which sets the directory, base name and file format in one go e.g. `some_dir/my_results.feather`.