### PR TITLE
fix: Fix ambiguous column name

### DIFF
--- a/cohortextractor/tpp_backend.py
+++ b/cohortextractor/tpp_backend.py
@@ -1191,6 +1191,7 @@ class TPPBackend:
             date_aggregate = "MAX"
 
         column_name = returning
+        outer_column_definition = None
         if returning == "binary_flag" or returning == "date":
             column_name = "binary_flag"
             column_definition = "1"
@@ -1212,7 +1213,8 @@ class TPPBackend:
                     "Cannot return categories because the supplied codelist does "
                     "not have any categories defined"
                 )
-            column_definition = "category"
+            outer_column_definition = "category"
+            column_definition = f"{codelist_table}.category"
             use_partition_query = True
         else:
             raise ValueError(f"Unsupported `returning` value: {returning}")
@@ -1222,11 +1224,13 @@ class TPPBackend:
                 from_table_id_col = "CodedEvent_ID"
             else:
                 from_table_id_col = f"{from_table}_ID"
+            if outer_column_definition is None:
+                outer_column_definition = column_definition
 
             sql = f"""
             SELECT
               Patient_ID AS patient_id,
-              {column_definition} AS {column_name},
+              {outer_column_definition} AS {column_name},
               {additional_columns}
               ConsultationDate AS date
             FROM (


### PR DESCRIPTION
If you try to return the matching category from a codelist using a date
drawn from another query which itself also returns a cateogry then you
get the error:

    Ambiguous column name 'category'

Example of a problematic query here:
https://github.com/opensafely/amr-uom-brit/blob/4c0879664ca/analysis/study_definition_ab_type_OS_new_2021.py#L110-L134