### PR TITLE
fix: Always enable date range fix

### DIFF
--- a/cohortextractor/cohortextractor.py
+++ b/cohortextractor/cohortextractor.py
@@ -31,7 +31,6 @@ from pandas.api.types import (
 )
 
 import cohortextractor
-from cohortextractor import flags
 from cohortextractor.exceptions import DummyDataValidationError, ValidationError
 from cohortextractor.generate_codelist_report import generate_codelist_report
 
@@ -845,11 +844,6 @@ def main(args=None):
     elif not hasattr(options, "which"):
         parser.print_help()
     elif options.which == "generate_cohort":
-        # This defaults to False for now (when --with-end-date-fix is not provided) so that
-        # study outputs don't change unexpectedly.  After some more investigation, we'll
-        # change the default to True (via --without-end-date-fix).
-        flags.WITH_END_DATE_FIX = bool(options.with_end_date_fix)
-
         if options.database_url:
             os.environ["DATABASE_URL"] = options.database_url
         if options.temp_database_name:

--- a/cohortextractor/emis_backend.py
+++ b/cohortextractor/emis_backend.py
@@ -6,7 +6,6 @@ import uuid
 
 import structlog
 
-from . import flags
 from .codelistlib import codelist
 from .csv_utils import is_csv_filename, write_rows_to_csv
 from .date_expressions import TrinoDateFormatter
@@ -544,10 +543,9 @@ class EMISBackend:
         min_date, max_date = between
         min_date_expr, join_tables1 = self.date_ref_to_sql_expr(min_date)
         max_date_expr, join_tables2 = self.date_ref_to_sql_expr(max_date)
-        if flags.WITH_END_DATE_FIX:
-            date_expr = TrinoDateFormatter.cast_as_date(date_expr)
-            min_date_expr = TrinoDateFormatter.cast_as_date(min_date_expr)
-            max_date_expr = TrinoDateFormatter.cast_as_date(max_date_expr)
+        date_expr = TrinoDateFormatter.cast_as_date(date_expr)
+        min_date_expr = TrinoDateFormatter.cast_as_date(min_date_expr)
+        max_date_expr = TrinoDateFormatter.cast_as_date(max_date_expr)
 
         joins = [
             f"LEFT JOIN {join_table}\n"

--- a/cohortextractor/flags.py
+++ b/cohortextractor/flags.py
@@ -1,4 +1,0 @@
-# If True, the between and on_or_before parameters capture events that occur after
-# midnight on the given end date.
-# This is a flag to allow us to easily check differences in the output.
-WITH_END_DATE_FIX = True

--- a/cohortextractor/tpp_backend.py
+++ b/cohortextractor/tpp_backend.py
@@ -9,7 +9,6 @@ import uuid
 import pandas
 import structlog
 
-from . import flags
 from .csv_utils import is_csv_filename, write_rows_to_csv
 from .date_expressions import MSSQLDateFormatter
 from .expressions import format_expression
@@ -645,10 +644,9 @@ class TPPBackend:
         min_date, max_date = between
         min_date_expr, join_tables1 = self.date_ref_to_sql_expr(min_date)
         max_date_expr, join_tables2 = self.date_ref_to_sql_expr(max_date)
-        if flags.WITH_END_DATE_FIX:
-            date_expr = MSSQLDateFormatter.cast_as_date(date_expr)
-            min_date_expr = MSSQLDateFormatter.cast_as_date(min_date_expr)
-            max_date_expr = MSSQLDateFormatter.cast_as_date(max_date_expr)
+        date_expr = MSSQLDateFormatter.cast_as_date(date_expr)
+        min_date_expr = MSSQLDateFormatter.cast_as_date(min_date_expr)
+        max_date_expr = MSSQLDateFormatter.cast_as_date(max_date_expr)
         joins = [
             f"LEFT JOIN {join_table}\n"
             f"ON {join_table}.patient_id = {table}.patient_id"

--- a/tests/test_cohortextractor.py
+++ b/tests/test_cohortextractor.py
@@ -6,7 +6,7 @@ from unittest.mock import patch
 import pytest
 
 from cohortextractor import MissingParameterError, params
-from cohortextractor.cohortextractor import flags, list_study_definitions, main
+from cohortextractor.cohortextractor import list_study_definitions, main
 
 
 @contextmanager
@@ -48,9 +48,6 @@ class PatchStack(ExitStack):
 @pytest.fixture
 def patch_generate_cohort(monkeypatch):
     monkeypatch.setenv("DATABASE_URL", "mssql://")
-    # We don't care what value we use here as `main()` will change that value in any
-    # case, we just want to make sure it's reset to the original value when we're done
-    monkeypatch.setattr(flags, "WITH_END_DATE_FIX", None)
     module = "cohortextractor.cohortextractor"
     with PatchStack() as patch:
         patch(

--- a/tests/test_emis_backend.py
+++ b/tests/test_emis_backend.py
@@ -6,7 +6,7 @@ import tempfile
 import pandas
 import pytest
 
-from cohortextractor import StudyDefinition, codelist, flags, patients
+from cohortextractor import StudyDefinition, codelist, patients
 from cohortextractor.date_expressions import InvalidExpressionError
 from cohortextractor.emis_backend import quote, truncate_patient_id
 from cohortextractor.patients import (
@@ -2686,10 +2686,7 @@ def test_patients_died_from_any_cause_dynamic_dates():
     )
 
 
-@pytest.mark.parametrize("with_end_date_fix", [True, False])
-def test_date_window_behaviour_literals(monkeypatch, with_end_date_fix):
-    monkeypatch.setattr(flags, "WITH_END_DATE_FIX", with_end_date_fix)
-
+def test_date_window_behaviour_literals():
     session = make_session()
     session.add_all(
         [
@@ -2727,16 +2724,10 @@ def test_date_window_behaviour_literals(monkeypatch, with_end_date_fix):
     )
 
     results = study.to_dicts()
-    if with_end_date_fix:
-        assert results[0]["event_count"] == "2"
-    else:
-        assert results[0]["event_count"] == "1"
+    assert results[0]["event_count"] == "2"
 
 
-@pytest.mark.parametrize("with_end_date_fix", [True, False])
-def test_date_window_behaviour_variable(monkeypatch, with_end_date_fix):
-    monkeypatch.setattr(flags, "WITH_END_DATE_FIX", with_end_date_fix)
-
+def test_date_window_behaviour_variable():
     session = make_session()
     session.add_all(
         [
@@ -2789,9 +2780,5 @@ def test_date_window_behaviour_variable(monkeypatch, with_end_date_fix):
     )
 
     results = study.to_dicts()
-    if with_end_date_fix:
-        assert results[0]["last_222"] == "2021-01-04"
-        assert results[0]["event_count"] == "2"
-    else:
-        assert results[0]["last_222"] == "2021-01-03"
-        assert results[0]["event_count"] == "1"
+    assert results[0]["last_222"] == "2021-01-04"
+    assert results[0]["event_count"] == "2"

--- a/tests/test_tpp_backend.py
+++ b/tests/test_tpp_backend.py
@@ -9,7 +9,7 @@ from unittest.mock import patch
 import pandas
 import pytest
 
-from cohortextractor import StudyDefinition, codelist, flags, patients, tpp_backend
+from cohortextractor import StudyDefinition, codelist, patients, tpp_backend
 from cohortextractor.date_expressions import InvalidExpressionError
 from cohortextractor.mssql_utils import mssql_connection_params_from_url
 from cohortextractor.patients import (
@@ -1749,10 +1749,7 @@ def test_patients_address_as_of():
     )
 
 
-@pytest.mark.parametrize("with_end_date_fix", [True, False])
-def test_date_window_behaviour_literals(monkeypatch, with_end_date_fix):
-    monkeypatch.setattr(flags, "WITH_END_DATE_FIX", with_end_date_fix)
-
+def test_date_window_behaviour_literals():
     session = make_session()
     session.add_all(
         [
@@ -1782,16 +1779,10 @@ def test_date_window_behaviour_literals(monkeypatch, with_end_date_fix):
     )
 
     results = study.to_dicts()
-    if with_end_date_fix:
-        assert results[0]["event_count"] == "2"
-    else:
-        assert results[0]["event_count"] == "1"
+    assert results[0]["event_count"] == "2"
 
 
-@pytest.mark.parametrize("with_end_date_fix", [True, False])
-def test_date_window_behaviour_variable(monkeypatch, with_end_date_fix):
-    monkeypatch.setattr(flags, "WITH_END_DATE_FIX", with_end_date_fix)
-
+def test_date_window_behaviour_variable():
     session = make_session()
     session.add_all(
         [
@@ -1832,12 +1823,8 @@ def test_date_window_behaviour_variable(monkeypatch, with_end_date_fix):
     )
 
     results = study.to_dicts()
-    if with_end_date_fix:
-        assert results[0]["last_bar"] == "2021-01-04"
-        assert results[0]["event_count"] == "2"
-    else:
-        assert results[0]["last_bar"] == "2021-01-03"
-        assert results[0]["event_count"] == "1"
+    assert results[0]["last_bar"] == "2021-01-04"
+    assert results[0]["event_count"] == "2"
 
 
 def test_index_of_multiple_deprivation():


### PR DESCRIPTION
The deleted comment talks about adding a --without-fix flag, but I think that introduces unnecessary complexity and we can add it later if we need to.