### PR TITLE
fix: Allow both `--output-file` and `--output-dir` to be set

### DIFF
--- a/cohortextractor/cohortextractor.py
+++ b/cohortextractor/cohortextractor.py
@@ -864,11 +864,6 @@ def main(args=None):
                 "--expectations-population --dummy-data-file --database-url is required"
             )
         if options.output_file:
-            if options.output_dir or options.output_format:
-                parser.error(
-                    "generate_cohort: error: cannot combine --output-file argument "
-                    "with --output-dir or --output-format"
-                )
             output_dir = options.output_file.parent
             match = re.match(
                 rf"^(.+)\.({EXTENSION_REGEX})$", str(options.output_file.name)
@@ -880,6 +875,19 @@ def main(args=None):
                 )
             output_name = match.group(1)
             output_format = match.group(2)
+            # It would be simpler if we could just insist that these other options
+            # weren't present, but job-runner adds `--output-dir` automatically so we
+            # can't do that.
+            if options.output_dir and options.output_dir != str(output_dir):
+                parser.error(
+                    f"generate_cohort: error: --output-dir '{options.output_dir}' "
+                    f"does not match directory in --output-file"
+                )
+            if options.output_format and options.output_format != output_format:
+                parser.error(
+                    f"generate_cohort: error: --output-format '{options.output_format}' "
+                    f"does not match format in --output-file"
+                )
         else:
             output_dir = options.output_dir or "output"
             output_name = None

--- a/tests/test_cohortextractor.py
+++ b/tests/test_cohortextractor.py
@@ -65,7 +65,7 @@ def patch_generate_cohort(monkeypatch):
 
 
 @pytest.mark.parametrize("option", ["--output-dir", "--output-format"])
-def test_output_file_cannot_be_combined_with_some_options(
+def test_output_file_cannot_be_combined_with_conflicting_options(
     option, patch_generate_cohort, capsys
 ):
     with pytest.raises(SystemExit):
@@ -75,10 +75,27 @@ def test_output_file_cannot_be_combined_with_some_options(
                 "--output-file",
                 "output/input.csv",
                 option,
-                "csv",
+                "feather",
             ]
         )
-    assert "cannot combine --output-file argument" in capsys.readouterr().err
+    assert f"{option} 'feather' does not match" in capsys.readouterr().err
+
+
+def test_output_file_can_be_combined_with_matching_options(patch_generate_cohort):
+    main(
+        [
+            "generate_cohort",
+            "--study-definition",
+            "study_definition",
+            "--output-file",
+            "mydir/input.feather",
+            "--output-dir",
+            "mydir",
+            "--output-format",
+            "feather",
+        ]
+    )
+    patch_generate_cohort.assert_called_once()
 
 
 def test_output_file_can_only_be_used_with_single_study(patch_generate_cohort, capsys):


### PR DESCRIPTION
The latter is redundant, but job-runner insists on adding it to the `run` command in any case so we can't just reject it outright. Instead we now check that it agrees with the directory in `--output-file` and only throw an error if they're different.

For consistency we do the same with `--output-format` although job-runner doesn't inject that for us.