### PR TITLE
fix: Handle another type of transient database error

### DIFF
--- a/cohortextractor/cohortextractor.py
+++ b/cohortextractor/cohortextractor.py
@@ -913,7 +913,11 @@ def main(args=None):
 
             traceback.print_exc()
             # Exit with specific exit codes to help identify known issues
-            if "Unexpected EOF from the server" in str(e):
+            transient_errors = [
+                "Unexpected EOF from the server",
+                "DBPROCESS is dead or not enabled",
+            ]
+            if any(message in str(e) for message in transient_errors):
                 logger.error(f"Intermittent database error: {e}")
                 sys.exit(3)
             if "Invalid object name 'CodedEvent_SNOMED'" in str(e):


### PR DESCRIPTION
We've known about this type of error for ages (see [issue][1]) but when we first wrote this error handling code (#791) we hadn't seen it in a while so we decided to exclude it and see if it reoccurs. It has reoccurred; not terribly often but enough times that it's worth handling it here.

Note that transient errors which occur when downloading results are automatically handled by the retry code so we never see them. This error handling concerns errors which occur before we've finished generating the results.

[1]: https://github.com/opensafely-core/cohort-extractor/issues/776#issuecomment-1091675829