### PR TITLE
Fix warning callout

### DIFF
--- a/cohortextractor/patients.py
+++ b/cohortextractor/patients.py
@@ -1825,13 +1825,13 @@ def with_gp_consultations(
 ):
     """
     !!! warning
-    A "consultation" as returned by this function may not actually be a consultation between a health care professional and patient.
+        A "consultation" as returned by this function may not actually be a consultation between a health care professional and patient.
 
-    For example, simple administrative tasks such as updating a patient's details may also cause creation of a "consultation" record.
+        For example, simple administrative tasks such as updating a patient's details may also cause creation of a "consultation" record.
 
-    It is, therefore, extremely unlikely you can use this field to infer anything about real clinician-patient interactions,
-    and it is even more difficult to compare activity between practices as recording behaviour can vary.
-    Some EHRs even delete consultation data for a patient when they switch practice.
+        It is, therefore, extremely unlikely you can use this field to infer anything about real clinician-patient interactions,
+        and it is even more difficult to compare activity between practices as recording behaviour can vary.
+        Some EHRs even delete consultation data for a patient when they switch practice.
 
     These are GP-patient interactions, either in person or via phone/video
     call. The concept of a "consultation" in EHR systems is generally broader


### PR DESCRIPTION
The text hasn't changed; it's simply indented by four spaces such that MkDocs formats it as a callout. This avoids [an empty warning callout](https://docs.opensafely.org/study-def-variables/#cohortextractor.patients.with_gp_consultations).