### PR TITLE
Use --extend-exclude and remove existing excludes

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,14 +1,10 @@
 [tool.black]
-exclude = '''
+extend-exclude = '''
 (
   /(
-      \.git         # exclude a few common directories in the
-    | \.direnv      # root of the project
-    | \.venv
-    | certs
+      certs
     | mssql
     | starburst
-    | venv
   )/
 )
 '''


### PR DESCRIPTION
By default (according to --help as of v22.8.0) black is already ignoring this list of directories:

/(\.direnv|\.eggs|\.git|\.hg|\.mypy_cache|\.nox|\.tox|\.venv|venv|\.svn|_build|buck-out|build|dist|__pypackages__)/

By using --extend-exclude we can layer on top of that.

Refs: opensafely-core/repo-template#85