### PR TITLE
fix: Fix regex identifying shortcut-able date expressions

### DIFF
--- a/cohortextractor/date_expressions.py
+++ b/cohortextractor/date_expressions.py
@@ -322,8 +322,9 @@ class MSSQLDateFormatter(DateFormatter):
         """
         date_format = date_column.date_format
         date_sql = re.sub(r"\s", "", str(date_column))
+        # e.g. ISNULL(CONVERT(VARCHAR(10),#some_table.[some_column],23),'')
         match = re.match(
-            r"ISNULL\(CONVERT\(VARCHAR\(\d+\),([#\w\.]+),23\),''\)", date_sql
+            r"ISNULL\(CONVERT\(VARCHAR\(\d+\),([#\w\.\[\]]+),23\),''\)", date_sql
         )
         if match:
             column_ref = match.group(1)


### PR DESCRIPTION
For $REASONS, when generating the SQL expression to access a date column, cohortextractor wraps the column in a function to format it as a string. If we want to then do date arithmetic on this value we have to parse it back to a date. To try to mitigate this terribleness a bit we try to spot cases where we're formatting a date as a string only to immediately parse it again and then rewrite the expression to shortcut this process. We identify these patterns using a regex.

In #875 we started quoting all column names to avoid issues where SQL keywords were used as names (prior to the `with_value_from_file()` code, column names had never been user-definable to this hadn't been a problem).

However the addition of the `[` and `]` characters to the column names broke the regex designed to spot shortcut-able patterns.

I don't have much to say about this beyond really, _really_ wanting to get Data Builder production-ready.