### PR TITLE
fix: add version and build timestamps labesl to docker image.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -116,6 +116,13 @@ COPY . /app
 # we run the docker image
 RUN cohortextractor --help
 
+ARG BUILD_DATE
+ARG VERSION
+ARG REVISION
+# RFC 3339.
+LABEL org.opencontainers.image.created=$BUILD_DATE \
+      org.opencontainers.image.version=$VERSION \
+      org.opencontainers.image.revision=$REVISION
 
 ################################################
 #

--- a/Makefile
+++ b/Makefile
@@ -44,7 +44,8 @@ $(VIRTUAL_ENV):
 # build the production docker image
 .PHONY: docker-build
 docker-build: export BUILD_DATE=$(shell date +'%y-%m-%dT%H:%M:%S.%3NZ')
-docker-build: export GITREF=$(shell git rev-parse --short HEAD)
+docker-build: export REVISION=$(shell git rev-parse --short HEAD)
+docker-build: export VERSION=$(shell git describe --tags)
 docker-build: export DOCKER_BUILDKIT=1
 docker-build: ENV=dev
 docker-build:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -36,7 +36,8 @@ services:
         - BUILDKIT_INLINE_CACHE=1
         # env vars supplied by make/just
         - BUILD_DATE
-        - GITREF
+        - REVISION
+        - VERSION
     init: true
 
   # used to build and run the development image, with test dependencies and
@@ -51,7 +52,7 @@ services:
       TPP_DATABASE_URL: "mssql://SA:Your_password123!@mssql:1433/Test_OpenCorona"
       EMIS_DATABASE_URL: "trino://trino:8080/mssql/dbo"
       EMIS_DATASOURCE_DATABASE_URL: "mssql://SA:Your_password123!@mssql:1433/Test_EMIS"
-      # uncommit for query logs
+      # uncomment for mssql query logs
       # TDSDUMP: stdout
     volumes:
       - .:/app


### PR DESCRIPTION
This was an oversight, or somehow got removed.

This allows us to tag telemetry about jobs with the specific
cohortextractor version it was run with.
