### PR TITLE
Temporarily remove scheduled Trino version check

### DIFF
--- a/.github/workflows/emis_trino_version_check.yaml
+++ b/.github/workflows/emis_trino_version_check.yaml
@@ -2,8 +2,6 @@ name: Check Trino version on EMIS and in docker-compose.yml match
 
 on:
   workflow_dispatch:
-  schedule:
-    - cron: '0 8 * * 1-5'
 
 jobs:
   check-trino-version:


### PR DESCRIPTION
#856 has been open for a few months and it has not been resolved.

In the meantime, this check only serves to spam my GitHub notifications every single weekday, to inform of the same problem.

This change should be reverted when #856 is fixed.