### PR TITLE
feat: Update name of ONS_CIS table

### DIFF
--- a/cohortextractor/tpp_backend.py
+++ b/cohortextractor/tpp_backend.py
@@ -3402,7 +3402,7 @@ class TPPBackend:
                 f"""
             -- Creating ons_cis temp table
             SELECT DISTINCT Patient_ID, {', '.join(ONS_CIS_COLUMN_MAPPINGS)}
-             INTO {self._ons_cis_table_name} FROM ONS_CIS
+             INTO {self._ons_cis_table_name} FROM ONS_CIS_New
             """
             ]
         else:

--- a/tests/tpp_backend_setup.py
+++ b/tests/tpp_backend_setup.py
@@ -1025,7 +1025,7 @@ for name, type_ in ISARIC_COLUMN_MAPPINGS.items():
 
 
 class ONS_CIS(Base):
-    __tablename__ = "ONS_CIS"
+    __tablename__ = "ONS_CIS_New"
 
     # fake pk to satisfy the ORM
     id = Column(Integer, primary_key=True)


### PR DESCRIPTION
For reasons I don't understand, the ONS CIS data is now in a table called ONS_CIS_New.