### PR TITLE
fix: Switch ONS CIS `visit_id` to `pseudo_visit_id`

### DIFF
--- a/cohortextractor/ons_cis_utils.py
+++ b/cohortextractor/ons_cis_utils.py
@@ -79,7 +79,7 @@ ONS_CIS_COLUMN_MAPPINGS = {
     "travel_abroad": "bool",
     "travel_abroad_date": "date",
     "visit_date": "date",
-    "visit_id": "str",
+    "pseudo_visit_id": "bytes",
     "work_direct_contact_patients_etc": "bool",
     "work_location": "int",
     "work_outside_home_days": "int",

--- a/cohortextractor/study_definition.py
+++ b/cohortextractor/study_definition.py
@@ -291,6 +291,8 @@ class StudyDefinition:
                 dtypes[name] = "category"
             elif column_type == "float":
                 dtypes[name] = "float"
+            elif column_type == "bytes":
+                dtypes[name] = "bytes"
             else:
                 raise ValueError(
                     f"Unable to impute Pandas type for {column_type} "

--- a/cohortextractor/tpp_backend.py
+++ b/cohortextractor/tpp_backend.py
@@ -448,6 +448,8 @@ class TPPBackend:
             return 0
         elif column_type == "float":
             return 0.0
+        elif column_type == "bytes":
+            return 0
         else:
             raise ValueError(f"Unhandled column type: {column_type}")
 
@@ -3502,9 +3504,9 @@ class TPPBackend:
         )
 
         if use_partition_query:
-            # additionally ordering by visit_id should be enough to ensure consistent return
+            # additionally ordering by pseudo_visit_id should be enough to ensure consistent return
             # order in the event that there are duplicate values for the date_filter_column
-            # The raw dataset does have duplicate visit_ids, but these are typically complete
+            # The raw dataset does have duplicate pseudo_visit_ids, but these are typically complete
             # duplicate rows (which we've already filtered out) or duplicates between patients
             # which are presumably an error
             sql = f"""
@@ -3519,7 +3521,7 @@ class TPPBackend:
                     {table}.{date_filter_column},
                     ROW_NUMBER() OVER (
                     PARTITION BY {table}.Patient_ID
-                    ORDER BY {table}.{date_filter_column} {ordering}, visit_id
+                    ORDER BY {table}.{date_filter_column} {ordering}, pseudo_visit_id
                     ) AS rownum
                 FROM {table}
                 {date_joins}

--- a/tests/test_tpp_backend.py
+++ b/tests/test_tpp_backend.py
@@ -6402,6 +6402,7 @@ def test_ons_cis():
                         self_isolating=0,
                         ct_mean=12.345,
                         result_combined=0,
+                        pseudo_visit_id=bytes([1]),
                     ),
                 ],
             ),
@@ -6415,6 +6416,7 @@ def test_ons_cis():
                         country=1,
                         self_isolating=1,
                         result_combined=9,
+                        pseudo_visit_id=bytes([2]),
                     ),
                 ],
             ),
@@ -6428,6 +6430,7 @@ def test_ons_cis():
                         country=2,
                         self_isolating=0,
                         result_combined=12,
+                        pseudo_visit_id=bytes([3]),
                     ),
                     ONS_CIS(
                         age_at_visit=41,
@@ -6436,6 +6439,7 @@ def test_ons_cis():
                         result_tdi=1,
                         country=2,
                         self_isolating=0,
+                        pseudo_visit_id=bytes([4]),
                     ),
                     # duplicate record ignored in number_of_matches_in_period counts
                     ONS_CIS(
@@ -6445,6 +6449,7 @@ def test_ons_cis():
                         result_tdi=1,
                         country=2,
                         self_isolating=0,
+                        pseudo_visit_id=bytes([4]),
                     ),
                 ],
             ),
@@ -6543,6 +6548,11 @@ def test_ons_cis():
             find_first_match_in_period=True,
             date_filter_column="visit_date",
         ),
+        pseudo_visit_id=patients.with_an_ons_cis_record(
+            returning="pseudo_visit_id",
+            find_first_match_in_period=True,
+            date_filter_column="visit_date",
+        ),
     )
 
     assert_results(
@@ -6564,6 +6574,7 @@ def test_ons_cis():
         country_as_codes=["0", "1", ""],
         ct_mean=[12.345, 0, 0],
         result_combined=["Negative", "Void", "Unassayed"],
+        pseudo_visit_id=[bytes([1]), bytes([2]), bytes([3])],
     )
 
 

--- a/tests/tpp_backend_setup.py
+++ b/tests/tpp_backend_setup.py
@@ -11,6 +11,7 @@ from sqlalchemy import (
     Float,
     ForeignKey,
     Integer,
+    LargeBinary,
     String,
     types,
 )
@@ -1042,6 +1043,7 @@ sqlalchemy_type_conversion = {
     "float": Float,
     "str": String,
     "date": Date,
+    "bytes": LargeBinary,
 }
 for name, ons_cis_type in ONS_CIS_COLUMN_MAPPINGS.items():
     setattr(ONS_CIS, name, Column(sqlalchemy_type_conversion[ons_cis_type]))


### PR DESCRIPTION
`ONS_CIS.visit_id` has become `ONS_CIS_New.pseudo_visit_id`, and has switched from a `varchar` to a `varbinary`. We use this column to break ties, and don't reveal it to the user, so we simply switch names and types.