### PR TITLE
fix: Qualify column name to avoid clash with user-supplied table

### DIFF
--- a/cohortextractor/tpp_backend.py
+++ b/cohortextractor/tpp_backend.py
@@ -2619,7 +2619,7 @@ class TPPBackend:
               SELECT APCS.Patient_ID, {returning_column} AS {returning},
               ROW_NUMBER() OVER (
                 PARTITION BY APCS.Patient_ID
-                ORDER BY Admission_Date {ordering}, APCS.APCS_Ident
+                ORDER BY APCS.Admission_Date {ordering}, APCS.APCS_Ident
               ) AS rownum
               FROM APCS
               INNER JOIN APCS_Der


### PR DESCRIPTION
Avoiding this in the general case would be fiddly, so I've made the smallest possible change here.

See https://bennettoxford.slack.com/archives/C33TWNQ1J/p1677690662258539