### PR TITLE
Add `update_custom_medication_dictionary`

### DIFF
--- a/cohortextractor/cohortextractor.py
+++ b/cohortextractor/cohortextractor.py
@@ -32,6 +32,9 @@ from pandas.api.types import (
 
 import cohortextractor
 from cohortextractor.exceptions import DummyDataValidationError, ValidationError
+from cohortextractor.update_custom_medication_dictionary import (
+    update_custom_medication_dictionary,
+)
 from cohortextractor.update_vmp_mapping import update_vmp_mapping
 
 from .log_utils import log_execution_time, log_stats
@@ -813,6 +816,14 @@ def main(args=None):
     )
     update_vmp_mapping_parser.set_defaults(which="update_vmp_mapping")
 
+    update_custom_medication_dictionary_parser = subparsers.add_parser(
+        "update_custom_medication_dictionary",
+        help="Update CustomMedicationDictionary table",
+    )
+    update_custom_medication_dictionary_parser.set_defaults(
+        which="update_custom_medication_dictionary"
+    )
+
     options = parser.parse_args(sys.argv[1:] if args is None else args)
 
     if options.version:
@@ -928,6 +939,8 @@ def main(args=None):
         check_maintenance(options.current_mode)
     elif options.which == "update_vmp_mapping":
         update_vmp_mapping()
+    elif options.which == "update_custom_medication_dictionary":
+        update_custom_medication_dictionary()
 
 
 def dict_from_params(params):

--- a/cohortextractor/custom_medication_dictionary.csv
+++ b/cohortextractor/custom_medication_dictionary.csv
@@ -1,0 +1,1 @@
+DMD_ID,MultilexDrug_ID

--- a/cohortextractor/update_custom_medication_dictionary.py
+++ b/cohortextractor/update_custom_medication_dictionary.py
@@ -1,0 +1,47 @@
+import csv
+import os
+import pathlib
+
+from .mssql_utils import mssql_dbapi_connection_from_url
+
+CUSTOM_MEDICATION_DICTIONARY_CSV = pathlib.Path(__file__).with_name(
+    "custom_medication_dictionary.csv"
+)
+
+
+def update_custom_medication_dictionary():
+    """Update CustomMedicationDictionary table"""
+    temp_database_name = os.environ["TEMP_DATABASE_NAME"]
+    table = f"{temp_database_name}..CustomMedicationDictionary"
+
+    # Transaction behaviour cribbed from
+    # cohortextractor.tpp_backend.save_results_to_temporary_db
+    conn = mssql_dbapi_connection_from_url(os.environ["DATABASE_URL"])
+    previous_autocommit = conn.autocommit_state
+    conn.autocommit(False)
+    cursor = conn.cursor()
+    cursor.execute(
+        f"""
+        IF OBJECT_ID('{table}', 'U') IS NOT NULL
+            DROP TABLE {table}
+
+        CREATE TABLE {table} (
+            DMD_ID VARCHAR(50) COLLATE Latin1_General_CI_AS,
+            MultilexDrug_ID VARCHAR(767),
+        )
+        """
+    )
+    cursor.executemany(
+        f"INSERT INTO {table} VALUES (%s, %s)",
+        get_custom_medication_dictionary(),
+    )
+    conn.commit()
+    conn.autocommit(previous_autocommit)
+    conn.close()
+
+
+def get_custom_medication_dictionary():
+    with CUSTOM_MEDICATION_DICTIONARY_CSV.open(newline="") as f:
+        reader = csv.reader(f)
+        next(reader)  # skip header row
+        return [tuple(x) for x in reader]

--- a/tests/test_update_custom_medication_dictionary.py
+++ b/tests/test_update_custom_medication_dictionary.py
@@ -1,0 +1,56 @@
+import os
+
+from pymssql import OperationalError
+
+from cohortextractor import update_custom_medication_dictionary
+from cohortextractor.mssql_utils import mssql_dbapi_connection_from_url
+
+
+def test_update_custom_medication_dictionary(tmp_path, monkeypatch):
+    monkeypatch.setenv("DATABASE_URL", os.environ["TPP_DATABASE_URL"])
+    monkeypatch.setenv("TEMP_DATABASE_NAME", os.environ["TPP_TEMP_DATABASE_NAME"])
+
+    mapping_csv = tmp_path / "custom_medication_dictionary.csv"
+    monkeypatch.setattr(
+        update_custom_medication_dictionary,
+        "CUSTOM_MEDICATION_DICTIONARY_CSV",
+        mapping_csv,
+    )
+
+    conn = mssql_dbapi_connection_from_url(os.environ["DATABASE_URL"])
+    cursor = conn.cursor()
+
+    def write_mapping_csv(rows):
+        mapping_csv.write_text("\n".join(",".join(row) for row in rows))  # overwrites
+
+    def select():
+        temp_database_name = os.environ["TEMP_DATABASE_NAME"]
+        cursor.execute(
+            f"""
+            SELECT *
+            FROM {temp_database_name}..CustomMedicationDictionary
+            ORDER BY DMD_ID, MultilexDrug_ID
+            """
+        )
+
+    # First time: Does the table contain the expected mappings?
+    write_mapping_csv([("DMD_ID", "MultilexDrug_ID"), ("111111", "a"), ("222222", "b")])
+    update_custom_medication_dictionary.update_custom_medication_dictionary()
+    select()
+    assert list(cursor) == [("111111", "a"), ("222222", "b")]
+
+    # Second time: Was the old table dropped and a new table created?
+    write_mapping_csv([("DMD_ID", "MultilexDrug_ID"), ("333333", "c"), ("444444", "d")])
+    update_custom_medication_dictionary.update_custom_medication_dictionary()
+    select()
+    assert list(cursor) == [("333333", "c"), ("444444", "d")]
+
+    # Third time: Force the INSERT to error, by passing a DM+D ID that's too long. Did
+    # the transaction roll-back?
+    write_mapping_csv([("DMD_ID", "MultilexDrug_ID"), (f"{'5' * 60}", "e")])
+    try:
+        update_custom_medication_dictionary.update_custom_medication_dictionary()
+    except OperationalError:
+        pass
+    select()
+    assert list(cursor) == [("333333", "c"), ("444444", "d")]


### PR DESCRIPTION
This sub-command updates the `CustomMedicationDictionary` table. (In reality, it first drops and then creates it, but it's called "update" for consistency with `update_vmp_mapping`.) This table is required by opensafely-core/ehrql#1270. Whilst its maintenance should, arguably, be handled by a separate tool, we already drop and create tables in the temporary database in cohort-extractor, so the maintenance of this table is here for consistency.

The implementation follows that of `cohortextractor.update_vmp_mapping` closely. I've added a couple of QOL improvements to the test and, to preserve my sanity, avoided using `unittest.mock`.