### PR TITLE
fix: Explicitly commit after creating temporary tables

### DIFF
--- a/cohortextractor/tpp_backend.py
+++ b/cohortextractor/tpp_backend.py
@@ -237,11 +237,14 @@ class TPPBackend:
             cursor.execute(
                 f"SELECT * INTO {output_table} FROM ({final_query}) t WHERE 0=1"
             )
+            conn.commit()
             # Populate the temporary table
             cursor.execute(
                 f"INSERT INTO {output_table} SELECT * FROM ({final_query}) t"
             )
+            conn.commit()
             cursor.execute(f"CREATE INDEX ix_patient_id ON {output_table} (patient_id)")
+            conn.commit()
             logger.info(f"Downloading results from '{output_table}'")
         else:
             logger.info(f"Downloading results from previous run in '{output_table}'")


### PR DESCRIPTION
We removed these as part of #968. However pymssql defaults to holding an open transaction which defeats the point of the lock avoidance behaviour we implemented so we now make sure to explicitly commit after each step.
    
Theoretically we could just put the connection into autocommit mode, but we want to do the smallest possible change here while we observe the effect.
