### PR TITLE
fix: Set default T1OO config to false

### DIFF
--- a/cohortextractor/tpp_backend.py
+++ b/cohortextractor/tpp_backend.py
@@ -43,8 +43,7 @@ T1OO_TABLE = "PatientsWithTypeOneDissent"
 class TPPBackend:
     _db_connection = None
     _current_column_name = None
-    # TODO: Temporary default to support safe deployment
-    include_t1oo = True
+    include_t1oo = False
 
     def __init__(
         self,

--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -117,10 +117,11 @@ def test_study_definition_initial_stats_logging(logger):
     )
     assert get_stats_logs(logger.entries) == [
         # output columns include patient_id, and the 4 variables defined in the
-        # study defniiton, including event_date_2, which is defined as a parameter to
-        # event_min_date
+        # study definition - population, event_date_1, event_min_date and event_date_2,
+        # which is defined as a parameter to event_min_date
         # tables - Patient, temp event table for each codelist
-        {"output_column_count": 5, "table_count": 3, "table_joins_count": 2},
+        # joins - Patient to each event table, and t1oo
+        {"output_column_count": 5, "table_count": 3, "table_joins_count": 3},
         # variable_count is a count of the top-level variables defined in the study def (i.e. not event_date_2)
         {"variable_count": 4},
         # 2 variables use a codelist (event_date_1, and the nested event_date_2)
@@ -144,10 +145,10 @@ def test_stats_logging_tpp_backend(logger):
 
     # initial stats
     expected_initial_study_def_logs = [
-        # output columns include patient_id, and the 2 variables defined in the
-        # study defniiton
-        # tables - Patient, temp event table for codelist
-        {"output_column_count": 3, "table_count": 2, "table_joins_count": 1},
+        # output columns include patient_id, and the 2 variables (population, event)
+        # defined in the study defniiton
+        # tables - Patient, temp event table, t1oo for codelist
+        {"output_column_count": 3, "table_count": 2, "table_joins_count": 2},
         {"variable_count": 2},
         {"variables_using_codelist_count": 1},
         {"variable_using_codelist": "event", "codelist_size": 1},
@@ -298,7 +299,7 @@ def test_stats_logging_generate_cohort(
     expected_initial_study_def_logs = [
         # these 3 are logged from StudyDefinition instantiation
         # patient_id, population, sex - all from patient table, but we make one temp # table per variable
-        {"output_column_count": 3, "table_count": 2, "table_joins_count": 1},
+        {"output_column_count": 3, "table_count": 2, "table_joins_count": 2},
         {"variable_count": 2},  # population, sex
         {"variables_using_codelist_count": 0},
         # index_date_count logged from generate_cohort
@@ -450,7 +451,7 @@ def test_stats_logging_generate_cohort_with_index_dates(
         {"index_date_count": 3},
         {"min_index_date": "2020-01-01", "max_index_date": "2020-03-01"},
         # output_column/table/joins_count is logged in tpp_backend on backend instantiation so it's repeated for each index date
-        *[{"output_column_count": 3, "table_count": 2, "table_joins_count": 1}] * 4,
+        *[{"output_column_count": 3, "table_count": 2, "table_joins_count": 2}] * 4,
         *[
             {"resetting_backend_index_date": ix_date}
             for ix_date in expected_index_dates

--- a/tests/test_tpp_backend.py
+++ b/tests/test_tpp_backend.py
@@ -152,12 +152,12 @@ def setup_function(function):
         (
             "mssql://user:pass@localhost:4321/db",
             "mssql://user:pass@localhost:4321/db",
-            True,
+            False,
         ),
         (
             "mssql://user:pass@localhost:4321/db?param1=one&param2&param1=three",
             "mssql://user:pass@localhost:4321/db?param1=one&param1=three&param2=",
-            True,
+            False,
         ),
         (
             "mssql://user:pass@localhost:4321/db?opensafely_include_t1oo&param2=two",
@@ -246,6 +246,23 @@ def test_minimal_study_with_reserved_keywords():
     )
 
     assert_results(study.to_dicts(), all=["M", "F"], asc=["40", "55"])
+
+
+def test_minimal_study_with_t1oo_default():
+    # Test that type 1 opt-outs are excluded by default
+    session = make_session()
+    patient_1 = Patient(Patient_ID=1, DateOfBirth="1980-01-01", Sex="M")
+    patient_2 = Patient(Patient_ID=2, DateOfBirth="1965-01-01", Sex="F")
+    t1oo_1 = PatientsWithTypeOneDissent(Patient_ID=1)
+    session.add_all([patient_1, patient_2, t1oo_1])
+    session.commit()
+    study = StudyDefinition(
+        population=patients.all(),
+        all=patients.sex(),
+        asc=patients.age_as_of("2020-01-01"),
+    )
+    # patient_1 (M, age 40) excluded
+    assert_results(study.to_dicts(), all=["F"], asc=["55"])
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
The previous default was a temporary measure to facilitate deployment.