### PR TITLE
fix: Fix workflow permissions

### DIFF
--- a/.github/workflows/build_and_publish.yaml
+++ b/.github/workflows/build_and_publish.yaml
@@ -12,10 +12,6 @@ on:
 env:
   IMAGE_NAME: cohortextractor
 
-permissions:
-    packages: write
-
-
 jobs:
   tag-new-version:
     # This uses `conventional commits` to generate tags.  A full list


### PR DESCRIPTION
According to the Github docs, a "permissive" Github token (which is what we have) has "package: write" permissions by default: https://docs.github.com/en/actions/security-guides/automatic-token-authentication#permissions-for-the-github_token

And also according the Github docs, if you explicitly specify _any_ permission in the workflow flow then all permissions you haven't specified revert to `none`:
https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#defining-access-for-the-github_token-scopes

This means that explictly including `package: write` as we were doing is not only unnecessary but prevents us having permission to push version tags, meaning that the `tag-new-version` action failed with:

    Error: Resource not accessible by integration

Obviously Github's behaviour must have changed here because this did work successfully on 2023-08-01, which was when we last published a new version.