### PR TITLE
Update to Docker Compose v2 syntax

### DIFF
--- a/.github/workflows/test_runner.yaml
+++ b/.github/workflows/test_runner.yaml
@@ -42,7 +42,7 @@ jobs:
             touch requirements.*.txt
             make devenv
       - name: Start SQL Server and Trino instances for the tests
-        run: docker-compose up -d mssql trino
+        run: docker compose up -d mssql trino
       - name: Run tests
         run: |
           source ${{ github.workspace }}/venv/bin/activate
@@ -56,9 +56,9 @@ jobs:
       - name: Build docker
         run: make docker-build ENV=dev
       - name: Basic docker test
-        run: docker-compose run --rm -v $PWD:/workspace dev cohortextractor
+        run: docker compose run --rm -v $PWD:/workspace dev cohortextractor
       - name: Run unit tests in docker
-        run: docker-compose run --rm -v $PWD:/workspace dev pytest
+        run: docker compose run --rm -v $PWD:/workspace dev pytest
 
   build:
     name: Test we can build PyPI package

--- a/Makefile
+++ b/Makefile
@@ -49,7 +49,7 @@ docker-build: export VERSION=$(shell git describe --tags)
 docker-build: export DOCKER_BUILDKIT=1
 docker-build: ENV=dev
 docker-build:
-	docker-compose build --pull $(ARGS) $(ENV)
+	docker compose build --pull $(ARGS) $(ENV)
 
 
 


### PR DESCRIPTION
Docker Compose v1 is deprecated and has been removed from Github Actions Runner images:
https://github.blog/changelog/2024-04-10-github-hosted-runner-images-deprecation-notice-docker-compose-v1/ https://docs.docker.com/compose/migrate/

Note that I've only changed the invocations used in Github Actions because that's what I need to run in order to build a new image. It looks like we also use docker-compose locally. Probably that version will need updating and the various invocations fixing, but I don't have time for this right now.